### PR TITLE
RHReliableDatagram: add RETRY header flag to fix deduping

### DIFF
--- a/RHReliableDatagram.cpp
+++ b/RHReliableDatagram.cpp
@@ -53,7 +53,22 @@ bool RHReliableDatagram::sendtoWait(uint8_t* buf, uint8_t len, uint8_t address)
     while (retries++ <= _retries)
     {
 	setHeaderId(thisSequenceNumber);
-	setHeaderFlags(RH_FLAGS_NONE, RH_FLAGS_ACK); // Clear the ACK flag
+
+        // Set and clear header flags depending on if this is an
+        // initial send or a retry.
+        uint8_t headerFlagsToSet = RH_FLAGS_NONE;
+        // Always clear the ACK flag
+        uint8_t headerFlagsToClear = RH_FLAGS_ACK;
+        if (retries == 1) {
+            // On an initial send, clear the RETRY flag in case
+            // it was previously set
+            headerFlagsToClear |= RH_FLAGS_RETRY;
+        } else {
+            // Not an initial send, set the RETRY flag
+            headerFlagsToSet = RH_FLAGS_RETRY;
+        }
+        setHeaderFlags(headerFlagsToSet, headerFlagsToClear);
+
 	sendto(buf, len, address);
 	waitPacketSent();
 
@@ -130,8 +145,13 @@ bool RHReliableDatagram::recvfromAck(uint8_t* buf, uint8_t* len, uint8_t* from, 
 		// Acknowledge message with ACK set in flags and ID set to received ID
 		acknowledge(_id, _from);
 	    }
-	    // If we have not seen this message before, then we are interested in it
-	    if (_id != _seenIds[_from])
+            // Filter out retried messages that we have seen before. This explicitly
+            // only filters out messages that are marked as retries to protect against
+            // the scenario where a transmitting device sends just one message and
+            // shuts down between transmissions. Devices that do this will report the
+            // the same ID each time since their internal sequence number will reset
+            // to zero each time the device starts up.
+	    if (!(_flags & RH_FLAGS_RETRY) || _id != _seenIds[_from])
 	    {
 		if (from)  *from =  _from;
 		if (to)    *to =    _to;

--- a/RHReliableDatagram.h
+++ b/RHReliableDatagram.h
@@ -9,10 +9,15 @@
 
 #include <RHDatagram.h>
 
-// The acknowledgement bit in the FLAGS
 // The top 4 bits of the flags are reserved for RadioHead. The lower 4 bits are reserved
 // for application layer use.
+
+/// The acknowledgement bit in the header FLAGS. This indicates if the payload is for an
+/// ack for a successfully received message.
 #define RH_FLAGS_ACK 0x80
+/// The retry bit in the header FLAGS. This indicates that the payload is a retry for a
+/// previously sent message.
+#define RH_FLAGS_RETRY 0x40
 
 /// the default retry timeout in milliseconds
 #define RH_DEFAULT_TIMEOUT 200


### PR DESCRIPTION
This commit introduces a new header flag (RH_FLAGS_RETRY) that is
set when a message is retried. This flag is checked in combination
with the seen array to dedupe messages that have already been
received.

Previously, deduping ONLY used the seen array which stores the last
seen message ID for each node address. This is an issue in situations
where a receiving device is constantly powered and a transmitting
device periodically turns on, transmits, and shuts down. In this
scenario, the device that shuts down will always send a message
with the same ID since it's sequence number resets to zero when it
is power cycled. This issue is limited to devices that only send a
single message before shutting down. Sending more than one message
before shutting down would be an acceptable workaround for this
issue since only the last message ID is tracked and it is compared
with a simple equality check.

Note that this new header flag occupies one of the slots in the top
4 bits of the header flags that are reserved for the RadioHead lib.

Warning: deduping will be broken if some nodes in a network have this
change and others do not. This change requires that all nodes be
upgraded to have this new logic.