### PR TITLE
Jryle/bring to 1.86

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -8,6 +8,8 @@ RadioHead/RHCRC.cpp
 RadioHead/RHCRC.h
 RadioHead/RHDatagram.cpp
 RadioHead/RHDatagram.h
+RadioHead/RHEncryptedDriver.h
+RadioHead/RHEncryptedDriver.cpp
 RadioHead/RHGenericDriver.cpp
 RadioHead/RHGenericDriver.h
 RadioHead/RHGenericSPI.cpp
@@ -67,9 +69,11 @@ RadioHead/examples/cc110/cc110_server/cc110_server.pde
 RadioHead/examples/e32/e32_client/e32_client.pde
 RadioHead/examples/e32/e32_server/e32_server.pde
 RadioHead/examples/rf95/rf95_client/rf95_client.pde
+RadioHead/examples/rf95/rf95_server/rf95_server.pde
+RadioHead/examples/rf95/rf95_encrypted_client/rf95_encrypted_client.pde
+RadioHead/examples/rf95/rf95_encrypted_server/rf95_encrypted_server.pde
 RadioHead/examples/rf95/rf95_reliable_datagram_client/rf95_reliable_datagram_client.pde
 RadioHead/examples/rf95/rf95_reliable_datagram_server/rf95_reliable_datagram_server.pde
-RadioHead/examples/rf95/rf95_server/rf95_server.pde
 RadioHead/examples/rf22/rf22_client/rf22_client.pde
 RadioHead/examples/rf22/rf22_mesh_client/rf22_mesh_client.pde
 RadioHead/examples/rf22/rf22_mesh_server1/rf22_mesh_server1.pde
@@ -95,9 +99,11 @@ RadioHead/examples/rf69/rf69_server/rf69_server.pde
 RadioHead/examples/mrf89/mrf89_client/mrf89_client.pde
 RadioHead/examples/mrf89/mrf89_server/mrf89_server.pde
 RadioHead/examples/nrf24/nrf24_client/nrf24_client.pde
+RadioHead/examples/nrf24/nrf24_encrypted_server/nrf24_encrypted_server.pde
+RadioHead/examples/nrf24/nrf24_encrypted_client/nrf24_encrypted_client.pde
+RadioHead/examples/nrf24/nrf24_server/nrf24_server.pde
 RadioHead/examples/nrf24/nrf24_reliable_datagram_client/nrf24_reliable_datagram_client.pde
 RadioHead/examples/nrf24/nrf24_reliable_datagram_server/nrf24_reliable_datagram_server.pde
-RadioHead/examples/nrf24/nrf24_server/nrf24_server.pde
 RadioHead/examples/nrf51/nrf51_client/nrf51_client.pde
 RadioHead/examples/nrf51/nrf51_reliable_datagram_client/nrf51_reliable_datagram_client.pde
 RadioHead/examples/nrf51/nrf51_reliable_datagram_server/nrf51_reliable_datagram_server.pde

--- a/MANIFEST
+++ b/MANIFEST
@@ -20,6 +20,8 @@ RadioHead/RHReliableDatagram.cpp
 RadioHead/RHReliableDatagram.h
 RadioHead/RH_CC110.cpp
 RadioHead/RH_CC110.h
+RadioHead/RH_E32.cpp
+RadioHead/RH_E32.h
 RadioHead/RH_NRF24.cpp
 RadioHead/RH_NRF24.h
 RadioHead/RH_NRF51.cpp
@@ -62,6 +64,8 @@ RadioHead/examples/ask/ask_transmitter/ask_transmitter.pde
 RadioHead/examples/ask/ask_receiver/ask_receiver.pde
 RadioHead/examples/cc110/cc110_client/cc110_client.pde
 RadioHead/examples/cc110/cc110_server/cc110_server.pde
+RadioHead/examples/e32/e32_client/e32_client.pde
+RadioHead/examples/e32/e32_server/e32_server.pde
 RadioHead/examples/rf95/rf95_client/rf95_client.pde
 RadioHead/examples/rf95/rf95_reliable_datagram_client/rf95_reliable_datagram_client.pde
 RadioHead/examples/rf95/rf95_reliable_datagram_server/rf95_reliable_datagram_server.pde

--- a/RHEncryptedDriver.cpp
+++ b/RHEncryptedDriver.cpp
@@ -2,7 +2,7 @@
 //
 // Author: Philippe.Rochat'at'gmail.com
 // Contributed to the RadioHead project by the author
-// $Id: RHEncryptedDriver.cpp,v 1.3 2018/02/11 23:57:18 mikem Exp mikem $
+// $Id: RHEncryptedDriver.cpp,v 1.3 2018/02/11 23:57:18 mikem Exp $
 
 #include <RHEncryptedDriver.h>
 #ifdef RH_ENABLE_ENCRYPTION_MODULE

--- a/RHEncryptedDriver.cpp
+++ b/RHEncryptedDriver.cpp
@@ -2,7 +2,7 @@
 //
 // Author: Philippe.Rochat'at'gmail.com
 // Contributed to the RadioHead project by the author
-// $Id: RHEncryptedDriver.cpp,v 1.2 2017/10/03 06:04:59 mikem Exp mikem $
+// $Id: RHEncryptedDriver.cpp,v 1.2 2017/10/03 06:04:59 mikem Exp $
 
 #include <RHEncryptedDriver.h>
 #ifdef RH_ENABLE_ENCRYPTION_MODULE

--- a/RHEncryptedDriver.cpp
+++ b/RHEncryptedDriver.cpp
@@ -2,7 +2,7 @@
 //
 // Author: Philippe.Rochat'at'gmail.com
 // Contributed to the RadioHead project by the author
-// $Id: RHEncryptedDriver.cpp,v 1.2 2017/10/03 06:04:59 mikem Exp $
+// $Id: RHEncryptedDriver.cpp,v 1.3 2018/02/11 23:57:18 mikem Exp mikem $
 
 #include <RHEncryptedDriver.h>
 #ifdef RH_ENABLE_ENCRYPTION_MODULE
@@ -19,7 +19,7 @@ bool RHEncryptedDriver::recv(uint8_t* buf, uint8_t* len)
     int h = 0; // Index of output _buffer
 
     bool status = _driver.recv(_buffer, len);
-    if (status)
+    if (status && buf && len)
     {
 	int blockSize = _blockcipher.blockSize(); // Size of blocks used by encryption
 	int nbBlocks = *len / blockSize; 		  // Number of blocks in that message

--- a/RHEncryptedDriver.cpp
+++ b/RHEncryptedDriver.cpp
@@ -2,7 +2,7 @@
 //
 // Author: Philippe.Rochat'at'gmail.com
 // Contributed to the RadioHead project by the author
-// $Id: RHEncryptedDriver.cpp,v 1.1 2017/07/25 05:26:50 mikem Exp mikem $
+// $Id: RHEncryptedDriver.cpp,v 1.2 2017/10/03 06:04:59 mikem Exp mikem $
 
 #include <RHEncryptedDriver.h>
 #ifdef RH_ENABLE_ENCRYPTION_MODULE

--- a/RHEncryptedDriver.cpp
+++ b/RHEncryptedDriver.cpp
@@ -1,0 +1,159 @@
+// RHEncryptedDriver.cpp
+//
+// Author: Philippe.Rochat'at'gmail.com
+// Contributed to the RadioHead project by the author
+// $Id: RadioHead.h,v 1.65 2017/06/25 09:41:17 mikem Exp $
+
+#include <RHEncryptedDriver.h>
+#ifdef RH_ENABLE_ENCRYPTION_MODULE
+
+RHEncryptedDriver::RHEncryptedDriver(RHGenericDriver& driver, BlockCipher& blockcipher)
+    : _driver(driver),
+      _blockcipher(blockcipher)
+{
+    _buffer = (uint8_t *)calloc(_driver.maxMessageLength(), sizeof(uint8_t));
+}
+
+// Just a passthru method
+bool RHEncryptedDriver::available()
+{
+    return _driver.available();
+}
+bool RHEncryptedDriver::waitPacketSent()
+{
+    return _driver.waitPacketSent();
+}
+
+bool RHEncryptedDriver::recv(uint8_t* buf, uint8_t* len)
+{
+    int h = 0; // Index of output _buffer
+
+    bool status = _driver.recv(_buffer, len); // Was buf before
+    if (status)
+    {
+	int blockSize = _blockcipher.blockSize(); // Size of blocks used by encryption
+	int nbBlocks = *len / blockSize; 		  // Number of blocks in that message
+	if (nbBlocks * blockSize == *len)
+	{ // Or we have a missmatch ... this is probably not symetrically encrypted 
+	    for (int k = 0; k < nbBlocks; k++)
+	    {
+		// Decrypt each block
+		_blockcipher.decryptBlock(&buf[h], &_buffer[k*blockSize]); // Decrypt that block into buf	
+		h += blockSize;
+#ifdef STRICT_CONTENT_LEN	
+		if (k == 0)
+		{
+		    *len = buf[0]; // First byte contains length
+		    h--;			// First block is of length--
+		    for (int j = 0; j < blockSize - 1; j++)
+		    {
+			// Left shift every byte in that block
+			buf[j] = buf[j + 1];
+		    }
+		}
+#endif			
+	    }
+	}
+    }
+
+    return status;
+}
+
+bool RHEncryptedDriver::send(const uint8_t* data, uint8_t len)
+{
+    bool status = true;
+    int blockSize = _blockcipher.blockSize(); // Size of blocks used by encryption
+	
+    if (len == 0) // PassThru
+	return _driver.send(data, len);
+
+    if (_cipheringBlocks.blockSize != blockSize)
+    {
+	// Cipher has changed it's block size
+	_cipheringBlocks.inputBlock = (uint8_t *)realloc(_cipheringBlocks.inputBlock, blockSize);
+	_cipheringBlocks.blockSize = blockSize;	
+    }
+	
+    int max_message_length = maxMessageLength();
+#ifdef STRICT_CONTENT_LEN	
+    uint8_t nbBlocks = len / blockSize + 1; // How many blocks do we need for that message
+    uint8_t nbBpM = max_message_length + 1 / blockSize; // Max number of blocks per message
+#else
+    uint8_t nbBlocks = (len - 1) / blockSize + 1; // How many blocks do we need for that message
+    uint8_t nbBpM = max_message_length / blockSize; // Max number of blocks per message
+#endif	
+    int k = 0, j = 0; // k is block index, j is original message index
+#ifndef ALLOW_MULTIPLE_MSG	
+    for (k = 0; k < nbBpM && k * blockSize < len ; k++)
+    {
+	// k blocks in that message
+	int h = 0; // h is block content index
+#ifdef STRICT_CONTENT_LEN
+	if (k == 0)
+	    _cipheringBlocks.inputBlock[h++] = len; // put in first byte of first block the message length
+#endif		
+	while (h < blockSize)
+	{	
+	    // Copy each msg byte into inputBlock, and trail with 0 if necessary
+	    if (j < len)
+		_cipheringBlocks.inputBlock[h++] = data[j++];
+	    else
+		_cipheringBlocks.inputBlock[h++] = 0; // Completing with trailing 0
+	}
+	_blockcipher.encryptBlock(&_buffer[k * blockSize], _cipheringBlocks.inputBlock); // Cipher that message into _buffer
+    }
+//    Serial.println(max_message_length);
+//    Serial.println(nbBlocks);
+//    Serial.println(nbBpM);
+//    Serial.println(k);
+//    Serial.println(blockSize);
+//    printBuffer("single send", _buffer, k * blockSize);
+    if (!_driver.send(_buffer, k*blockSize))  // We now send that message with it's new length
+	status = false;
+#else	
+    uint8_t nbMsg = (nbBlocks * blockSize) / max_message_length + 1; // How many message do we need
+
+    for (int i = 0; i < nbMsg; i++)
+    {
+	// i is message index
+	for (k = 0; k < nbBpM && k * blockSize < len ; k++)
+	{
+	    // k blocks in that message
+	    int h = 0;
+#ifdef STRICT_CONTENT_LEN
+	    if (k == 0 && i == 0)
+		_cipheringBlocks.inputBlock[h++] = len; // put in first byte of first block of first message the message length
+#endif			
+	    while (h < blockSize)
+	    {		
+		// Copy each msg byte into inputBlock, and trail with 0 if necessary
+		if (j < len)
+		    _cipheringBlocks.inputBlock[h++] = data[j++];
+		else
+		    _cipheringBlocks.inputBlock[h++] = 0;
+	    }
+	    _blockcipher.encryptBlock(&_buffer[k * blockSize], _cipheringBlocks.inputBlock); // Cipher that message into buffer
+	}
+//	printBuffer("multiple send", _buffer, k * blockSize);
+	if (!_driver.send(_buffer, k * blockSize))  // We now send that message with it's new length
+	    status = false;
+    }
+#endif
+    return status;
+}
+
+uint8_t RHEncryptedDriver::maxMessageLength()
+{
+    int driver_len = _driver.maxMessageLength();
+    
+#ifndef ALLOW_MULTIPLE_MSG
+    driver_len = ((int)(driver_len/_blockcipher.blockSize()) ) * _blockcipher.blockSize();
+#endif
+
+#ifdef STRICT_CONTENT_LEN
+    driver_len--;
+#endif
+    return driver_len;
+}
+
+#endif

--- a/RHEncryptedDriver.cpp
+++ b/RHEncryptedDriver.cpp
@@ -76,7 +76,11 @@ bool RHEncryptedDriver::send(const uint8_t* data, uint8_t len)
 #endif	
     int k = 0, j = 0; // k is block index, j is original message index
 #ifndef ALLOW_MULTIPLE_MSG	
+#ifdef STRICT_CONTENT_LEN
+    for (k = 0; k < nbBpM && k * blockSize < len + 1; k++)
+#else
     for (k = 0; k < nbBpM && k * blockSize < len ; k++)
+#endif
     {
 	// k blocks in that message
 	int h = 0; // h is block content index

--- a/RHEncryptedDriver.h
+++ b/RHEncryptedDriver.h
@@ -31,7 +31,8 @@
 /// \brief Virtual Driver to encrypt/decrypt data. Can be used with any other RadioHead driver.
 ///
 /// This driver acts as a wrapper for any other RadioHead driver, adding encryption and decryption of
-/// messages that are passed to and from the actual radio driver. Any of the encryption ciphers supported by
+/// messages that are passed to and from the actual radio driver. Only the message payload is encrypted,
+/// and not the to/from address or flags. Any of the encryption ciphers supported by
 /// ArduinoLibs Cryptographic Library http://rweather.github.io/arduinolibs/crypto.html may be used.
 ///
 /// For successful communications, both sender and receiver must use the same cipher and the same key.

--- a/RHEncryptedDriver.h
+++ b/RHEncryptedDriver.h
@@ -7,7 +7,7 @@
 //
 // Author: Philippe.Rochat'at'gmail.com
 // Contributed to the RadioHead project by the author
-// $Id: RHEncryptedDriver.h,v 1.2 2017/10/03 06:04:59 mikem Exp mikem $
+// $Id: RHEncryptedDriver.h,v 1.2 2017/10/03 06:04:59 mikem Exp $
 
 #ifndef RHEncryptedDriver_h
 #define RHEncryptedDriver_h

--- a/RHEncryptedDriver.h
+++ b/RHEncryptedDriver.h
@@ -7,7 +7,7 @@
 //
 // Author: Philippe.Rochat'at'gmail.com
 // Contributed to the RadioHead project by the author
-// $Id: RHEncryptedDriver.h,v 1.1 2017/07/25 05:26:50 mikem Exp mikem $
+// $Id: RHEncryptedDriver.h,v 1.2 2017/10/03 06:04:59 mikem Exp mikem $
 
 #ifndef RHEncryptedDriver_h
 #define RHEncryptedDriver_h

--- a/RHEncryptedDriver.h
+++ b/RHEncryptedDriver.h
@@ -7,7 +7,7 @@
 //
 // Author: Philippe.Rochat'at'gmail.com
 // Contributed to the RadioHead project by the author
-// $Id: RadioHead.h,v 1.65 2017/06/25 09:41:17 mikem Exp $
+// $Id: RHEncryptedDriver.h,v 1.1 2017/07/25 05:26:50 mikem Exp mikem $
 
 #ifndef RHEncryptedDriver_h
 #define RHEncryptedDriver_h
@@ -28,16 +28,13 @@
 
 /////////////////////////////////////////////////////////////////////
 /// \class RHEncryptedDriver RHEncryptedDriver <RHEncryptedDriver.h>
-/// \brief Virtual Driver to encrypt/decrypt sent data. Could be used with any other driver.
+/// \brief Virtual Driver to encrypt/decrypt data. Can be used with any other RadioHead driver.
 ///
 /// This driver acts as a wrapper for any other RadioHead driver, adding encryption and decryption of
 /// messages that are passed to and from the actual radio driver. Any of the encryption ciphers supported by
 /// ArduinoLibs Cryptographic Library http://rweather.github.io/arduinolibs/crypto.html may be used.
 ///
 /// For successful communications, both sender and receiver must use the same cipher and the same key.
-///
-/// Just call the constructor with your real radio modem and a BlockCiphering class from the
-/// Arduinolibs: https://github.com/rweather/arduinolibs.
 ///
 /// In order to enable this module you must uncomment #define RH_ENABLE_ENCRYPTION_MODULE at the bottom of RadioHead.h
 /// But ensure you have installed the Crypto directory from arduinolibs first:
@@ -53,13 +50,17 @@ public:
     /// the blockcipher has had its key set before sending or receiving messages.
     RHEncryptedDriver(RHGenericDriver& driver, BlockCipher& blockcipher);
 	
+    /// Calls the real driver's init()
+    /// \return The value returned from the driver init() method;
+    virtual bool init() { return _driver.init();};
+    
     /// Tests whether a new message is available
     /// from the Driver. 
     /// On most drivers, this will also put the Driver into RHModeRx mode until
     /// a message is actually received by the transport, when it wil be returned to RHModeIdle.
     /// This can be called multiple times in a timeout loop
     /// \return true if a new, complete, error-free uncollected message is available to be retreived by recv()
-    virtual bool available();
+    virtual bool available() { return _driver.available();};
 
     /// Turns the receiver on if it not already on.
     /// If there is a valid message available, copy it to buf and return true
@@ -84,15 +85,134 @@ public:
     /// if CAD was requested and the CAD timeout timed out before clear channel was detected.
     virtual bool send(const uint8_t* data, uint8_t len);
 
-    /// Blocks until the transmitter 
-    /// is no longer transmitting.
-    virtual bool            waitPacketSent();
-
     /// Returns the maximum message length 
     /// available in this Driver, which depends on the maximum length supported by the underlying transport driver.
     /// \return The maximum legal message length
     virtual  uint8_t maxMessageLength();
 
+    /// Blocks until the transmitter 
+    /// is no longer transmitting.
+    virtual bool            waitPacketSent() { return _driver.waitPacketSent();} ;
+
+    /// Blocks until the transmitter is no longer transmitting.
+    /// or until the timeout occuers, whichever happens first
+    /// \param[in] timeout Maximum time to wait in milliseconds.
+    /// \return true if the radio completed transmission within the timeout period. False if it timed out.
+    virtual bool            waitPacketSent(uint16_t timeout) {return _driver.waitPacketSent(timeout);} ;
+
+    /// Starts the receiver and blocks until a received message is available or a timeout
+    /// \param[in] timeout Maximum time to wait in milliseconds.
+    /// \return true if a message is available
+    virtual bool            waitAvailableTimeout(uint16_t timeout) {return _driver.waitAvailableTimeout(timeout);};
+
+    /// Calls the waitCAD method in the driver
+    /// \return The return value from teh drivers waitCAD() method
+    virtual bool            waitCAD() { return _driver.waitCAD();};
+
+    /// Sets the Channel Activity Detection timeout in milliseconds to be used by waitCAD().
+    /// The default is 0, which means do not wait for CAD detection.
+    /// CAD detection depends on support for isChannelActive() by your particular radio.
+    void setCADTimeout(unsigned long cad_timeout) {_driver.setCADTimeout(cad_timeout);};
+
+    /// Determine if the currently selected radio channel is active.
+    /// This is expected to be subclassed by specific radios to implement their Channel Activity Detection
+    /// if supported. If the radio does not support CAD, returns true immediately. If a RadioHead radio 
+    /// supports isChannelActive() it will be documented in the radio specific documentation.
+    /// This is called automatically by waitCAD().
+    /// \return true if the radio-specific CAD (as returned by override of isChannelActive()) shows the
+    /// current radio channel as active, else false. If there is no radio-specific CAD, returns false.
+    virtual bool            isChannelActive() { return _driver.isChannelActive();};
+
+    /// Sets the address of this node. Defaults to 0xFF. Subclasses or the user may want to change this.
+    /// This will be used to test the adddress in incoming messages. In non-promiscuous mode,
+    /// only messages with a TO header the same as thisAddress or the broadcast addess (0xFF) will be accepted.
+    /// In promiscuous mode, all messages will be accepted regardless of the TO header.
+    /// In a conventional multinode system, all nodes will have a unique address 
+    /// (which you could store in EEPROM).
+    /// You would normally set the header FROM address to be the same as thisAddress (though you dont have to, 
+    /// allowing the possibilty of address spoofing).
+    /// \param[in] thisAddress The address of this node.
+    virtual void setThisAddress(uint8_t thisAddress) { _driver.setThisAddress(thisAddress);};
+
+    /// Sets the TO header to be sent in all subsequent messages
+    /// \param[in] to The new TO header value
+    virtual void           setHeaderTo(uint8_t to){ _driver.setHeaderTo(to);};
+
+    /// Sets the FROM header to be sent in all subsequent messages
+    /// \param[in] from The new FROM header value
+    virtual void           setHeaderFrom(uint8_t from){ _driver.setHeaderFrom(from);};
+
+    /// Sets the ID header to be sent in all subsequent messages
+    /// \param[in] id The new ID header value
+    virtual void           setHeaderId(uint8_t id){ _driver.setHeaderId(id);};
+
+    /// Sets and clears bits in the FLAGS header to be sent in all subsequent messages
+    /// First it clears he FLAGS according to the clear argument, then sets the flags according to the 
+    /// set argument. The default for clear always clears the application specific flags.
+    /// \param[in] set bitmask of bits to be set. Flags are cleared with the clear mask before being set.
+    /// \param[in] clear bitmask of flags to clear. Defaults to RH_FLAGS_APPLICATION_SPECIFIC
+    ///            which clears the application specific flags, resulting in new application specific flags
+    ///            identical to the set.
+    virtual void           setHeaderFlags(uint8_t set, uint8_t clear = RH_FLAGS_APPLICATION_SPECIFIC) { _driver.setHeaderFlags(set, clear);};
+
+    /// Tells the receiver to accept messages with any TO address, not just messages
+    /// addressed to thisAddress or the broadcast address
+    /// \param[in] promiscuous true if you wish to receive messages with any TO address
+    virtual void           setPromiscuous(bool promiscuous){ _driver.setPromiscuous(promiscuous);};
+
+    /// Returns the TO header of the last received message
+    /// \return The TO header
+    virtual uint8_t        headerTo() { return _driver.headerTo();};
+
+    /// Returns the FROM header of the last received message
+    /// \return The FROM header
+    virtual uint8_t        headerFrom() { return _driver.headerFrom();};
+
+    /// Returns the ID header of the last received message
+    /// \return The ID header
+    virtual uint8_t        headerId() { return _driver.headerId();};
+
+    /// Returns the FLAGS header of the last received message
+    /// \return The FLAGS header
+    virtual uint8_t        headerFlags() { return _driver.headerFlags();};
+
+    /// Returns the most recent RSSI (Receiver Signal Strength Indicator).
+    /// Usually it is the RSSI of the last received message, which is measured when the preamble is received.
+    /// If you called readRssi() more recently, it will return that more recent value.
+    /// \return The most recent RSSI measurement in dBm.
+    int16_t        lastRssi() { return _driver.lastRssi();};
+
+    /// Returns the operating mode of the library.
+    /// \return the current mode, one of RF69_MODE_*
+    RHMode          mode() { return _driver.mode();};
+
+    /// Sets the operating mode of the transport.
+    void            setMode(RHMode mode) { _driver.setMode(mode);};
+
+    /// Sets the transport hardware into low-power sleep mode
+    /// (if supported). May be overridden by specific drivers to initialte sleep mode.
+    /// If successful, the transport will stay in sleep mode until woken by 
+    /// changing mode it idle, transmit or receive (eg by calling send(), recv(), available() etc)
+    /// \return true if sleep mode is supported by transport hardware and the RadioHead driver, and if sleep mode
+    ///         was successfully entered. If sleep mode is not suported, return false.
+    virtual bool    sleep() { return _driver.sleep();};
+
+    /// Returns the count of the number of bad received packets (ie packets with bad lengths, checksum etc)
+    /// which were rejected and not delivered to the application.
+    /// Caution: not all drivers can correctly report this count. Some underlying hardware only report
+    /// good packets.
+    /// \return The number of bad packets received.
+    virtual uint16_t       rxBad() { return _driver.rxBad();};
+
+    /// Returns the count of the number of 
+    /// good received packets
+    /// \return The number of good packets received.
+    virtual uint16_t       rxGood() { return _driver.rxGood();};
+
+    /// Returns the count of the number of 
+    /// packets successfully transmitted (though not necessarily received by the destination)
+    /// \return The number of packets successfully transmitted
+    virtual uint16_t       txGood() { return _driver.txGood();};
 
 private:
     /// The underlying transport river we are to use
@@ -119,6 +239,8 @@ private:
 /// @example nrf24_encrypted_server.pde
 /// @example rf95_encrypted_client.pde
 /// @example rf95_encrypted_server.pde
+/// @example serial_encrypted_reliable_datagram_client.pde
+/// @example serial_encrypted_reliable_datagram_server.pde
 
 
 #endif

--- a/RHEncryptedDriver.h
+++ b/RHEncryptedDriver.h
@@ -1,0 +1,125 @@
+// RHEncryptedDriver.h
+
+// Generic encryption layer that could use any driver
+// But will encrypt all data.
+// Requires the Arduinolibs/Crypto library:
+// https://github.com/rweather/arduinolibs
+//
+// Author: Philippe.Rochat'at'gmail.com
+// Contributed to the RadioHead project by the author
+// $Id: RadioHead.h,v 1.65 2017/06/25 09:41:17 mikem Exp $
+
+#ifndef RHEncryptedDriver_h
+#define RHEncryptedDriver_h
+
+#include <RHGenericDriver.h>
+#ifdef RH_ENABLE_ENCRYPTION_MODULE
+#include <BlockCipher.h>
+
+// Undef this if trailing 0 on each enrypted message is ok.
+// This defined means a first byte of the payload is used to encode content length
+// And the received message content is trimmed to this length
+#define STRICT_CONTENT_LEN  
+
+// Define this to allow encrypted content to span over 2 messages
+// STRICT_CONTENT_LEN and ALLOW_MULTIPLE_MSG aren't compatible !!!
+// With STRICT_CONTENT_LEN, receiver will try to extract length from every message !!!!
+//#define ALLOW_MULTIPLE_MSG  
+
+/////////////////////////////////////////////////////////////////////
+/// \class RHEncryptedDriver RHEncryptedDriver <RHEncryptedDriver.h>
+/// \brief Virtual Driver to encrypt/decrypt sent data. Could be used with any other driver.
+///
+/// This driver acts as a wrapper for any other RadioHead driver, adding encryption and decryption of
+/// messages that are passed to and from the actual radio driver. Any of the encryption ciphers supported by
+/// ArduinoLibs Cryptographic Library http://rweather.github.io/arduinolibs/crypto.html may be used.
+///
+/// For successful communications, both sender and receiver must use the same cipher and the same key.
+///
+/// Just call the constructor with your real radio modem and a BlockCiphering class from the
+/// Arduinolibs: https://github.com/rweather/arduinolibs.
+///
+/// In order to enable this module you must uncomment #define RH_ENABLE_ENCRYPTION_MODULE at the bottom of RadioHead.h
+/// But ensure you have installed the Crypto directory from arduinolibs first:
+/// http://rweather.github.io/arduinolibs/index.html
+
+class RHEncryptedDriver : public RHGenericDriver
+{
+public:
+    /// Constructor.
+    /// Adds a ciphering layer to messages sent and received by the actual transport driver.
+    /// \param[in] driver The RadioHead driver to use to transport messages.
+    /// \param[in] blockcipher The blockcipher (from arduinolibs) that crypt/decrypt data. Ensure that
+    /// the blockcipher has had its key set before sending or receiving messages.
+    RHEncryptedDriver(RHGenericDriver& driver, BlockCipher& blockcipher);
+	
+    /// Tests whether a new message is available
+    /// from the Driver. 
+    /// On most drivers, this will also put the Driver into RHModeRx mode until
+    /// a message is actually received by the transport, when it wil be returned to RHModeIdle.
+    /// This can be called multiple times in a timeout loop
+    /// \return true if a new, complete, error-free uncollected message is available to be retreived by recv()
+    virtual bool available();
+
+    /// Turns the receiver on if it not already on.
+    /// If there is a valid message available, copy it to buf and return true
+    /// else return false.
+    /// If a message is copied, *len is set to the length (Caution, 0 length messages are permitted).
+    /// You should be sure to call this function frequently enough to not miss any messages
+    /// It is recommended that you call it in your main loop.
+    /// \param[in] buf Location to copy the received message
+    /// \param[in,out] len Pointer to available space in buf. Set to the actual number of octets copied.
+    /// \return true if a valid message was copied to buf
+    virtual bool recv(uint8_t* buf, uint8_t* len);
+
+    /// Waits until any previous transmit packet is finished being transmitted with waitPacketSent().
+    /// Then optionally waits for Channel Activity Detection (CAD) 
+    /// to show the channnel is clear (if the radio supports CAD) by calling waitCAD().
+    /// Then loads a message into the transmitter and starts the transmitter. Note that a message length
+    /// of 0 is permitted. 
+    /// \param[in] data Array of data to be sent
+    /// \param[in] len Number of bytes of data to send
+    /// specify the maximum time in ms to wait. If 0 (the default) do not wait for CAD before transmitting.
+    /// \return true if the message length was valid and it was correctly queued for transmit. Return false
+    /// if CAD was requested and the CAD timeout timed out before clear channel was detected.
+    virtual bool send(const uint8_t* data, uint8_t len);
+
+    /// Blocks until the transmitter 
+    /// is no longer transmitting.
+    virtual bool            waitPacketSent();
+
+    /// Returns the maximum message length 
+    /// available in this Driver, which depends on the maximum length supported by the underlying transport driver.
+    /// \return The maximum legal message length
+    virtual  uint8_t maxMessageLength();
+
+
+private:
+    /// The underlying transport river we are to use
+    RHGenericDriver&        _driver;
+    
+    /// The CipherBlock we are to use for encrypting/decrypting
+    BlockCipher&	    _blockcipher;
+    
+    /// Struct for with buffers for ciphering
+    typedef struct
+    {
+	size_t  blockSize    = 0;
+	uint8_t *inputBlock  = NULL;
+	//uint8_t *outputBlock = NULL;		
+    } CipherBlocks;
+    
+    CipherBlocks            _cipheringBlocks;
+    
+    /// Buffer to store encrypted/decrypted message
+    uint8_t*                _buffer;
+};
+
+/// @example nrf24_encrypted_client.pde
+/// @example nrf24_encrypted_server.pde
+/// @example rf95_encrypted_client.pde
+/// @example rf95_encrypted_server.pde
+
+
+#endif
+#endif

--- a/RHGenericDriver.cpp
+++ b/RHGenericDriver.cpp
@@ -1,7 +1,7 @@
 // RHGenericDriver.cpp
 //
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHGenericDriver.cpp,v 1.23 2018/02/11 23:57:18 mikem Exp mikem $
+// $Id: RHGenericDriver.cpp,v 1.23 2018/02/11 23:57:18 mikem Exp $
 
 #include <RHGenericDriver.h>
 

--- a/RHGenericDriver.cpp
+++ b/RHGenericDriver.cpp
@@ -1,7 +1,7 @@
 // RHGenericDriver.cpp
 //
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHGenericDriver.cpp,v 1.21 2017/03/04 00:59:41 mikem Exp $
+// $Id: RHGenericDriver.cpp,v 1.22 2017/06/24 20:36:15 mikem Exp $
 
 #include <RHGenericDriver.h>
 

--- a/RHGenericDriver.cpp
+++ b/RHGenericDriver.cpp
@@ -1,7 +1,7 @@
 // RHGenericDriver.cpp
 //
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHGenericDriver.cpp,v 1.22 2017/06/24 20:36:15 mikem Exp $
+// $Id: RHGenericDriver.cpp,v 1.23 2018/02/11 23:57:18 mikem Exp mikem $
 
 #include <RHGenericDriver.h>
 
@@ -174,10 +174,9 @@ bool  RHGenericDriver::sleep()
 // Diagnostic help
 void RHGenericDriver::printBuffer(const char* prompt, const uint8_t* buf, uint8_t len)
 {
-    uint8_t i;
-
 #ifdef RH_HAVE_SERIAL
     Serial.println(prompt);
+    uint8_t i;
     for (i = 0; i < len; i++)
     {
 	if (i % 16 == 15)

--- a/RHGenericDriver.cpp
+++ b/RHGenericDriver.cpp
@@ -151,7 +151,7 @@ uint8_t RHGenericDriver::headerFlags()
     return _rxHeaderFlags;
 }
 
-int8_t RHGenericDriver::lastRssi()
+int16_t RHGenericDriver::lastRssi()
 {
     return _lastRssi;
 }

--- a/RHGenericDriver.h
+++ b/RHGenericDriver.h
@@ -206,14 +206,14 @@ public:
     /// Usually it is the RSSI of the last received message, which is measured when the preamble is received.
     /// If you called readRssi() more recently, it will return that more recent value.
     /// \return The most recent RSSI measurement in dBm.
-    int16_t        lastRssi();
+    virtual int16_t        lastRssi();
 
     /// Returns the operating mode of the library.
     /// \return the current mode, one of RF69_MODE_*
-    RHMode          mode();
+    virtual RHMode          mode();
 
     /// Sets the operating mode of the transport.
-    void            setMode(RHMode mode);
+    virtual void            setMode(RHMode mode);
 
     /// Sets the transport hardware into low-power sleep mode
     /// (if supported). May be overridden by specific drivers to initialte sleep mode.

--- a/RHGenericDriver.h
+++ b/RHGenericDriver.h
@@ -1,7 +1,7 @@
 // RHGenericDriver.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHGenericDriver.h,v 1.19 2017/03/08 09:30:47 mikem Exp mikem $
+// $Id: RHGenericDriver.h,v 1.19 2017/03/08 09:30:47 mikem Exp $
 
 #ifndef RHGenericDriver_h
 #define RHGenericDriver_h

--- a/RHGenericDriver.h
+++ b/RHGenericDriver.h
@@ -1,7 +1,7 @@
 // RHGenericDriver.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHGenericDriver.h,v 1.20 2017/06/24 20:36:15 mikem Exp $
+// $Id: RHGenericDriver.h,v 1.21 2017/07/25 05:26:50 mikem Exp mikem $
 
 #ifndef RHGenericDriver_h
 #define RHGenericDriver_h
@@ -235,17 +235,17 @@ public:
     /// Caution: not all drivers can correctly report this count. Some underlying hardware only report
     /// good packets.
     /// \return The number of bad packets received.
-    uint16_t       rxBad();
+    virtual uint16_t       rxBad();
 
     /// Returns the count of the number of 
     /// good received packets
     /// \return The number of good packets received.
-    uint16_t       rxGood();
+    virtual uint16_t       rxGood();
 
     /// Returns the count of the number of 
     /// packets successfully transmitted (though not necessarily received by the destination)
     /// \return The number of packets successfully transmitted
-    uint16_t       txGood();
+    virtual uint16_t       txGood();
 
 protected:
 

--- a/RHGenericDriver.h
+++ b/RHGenericDriver.h
@@ -1,7 +1,7 @@
 // RHGenericDriver.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHGenericDriver.h,v 1.21 2017/07/25 05:26:50 mikem Exp mikem $
+// $Id: RHGenericDriver.h,v 1.22 2017/10/03 06:04:59 mikem Exp mikem $
 
 #ifndef RHGenericDriver_h
 #define RHGenericDriver_h

--- a/RHGenericDriver.h
+++ b/RHGenericDriver.h
@@ -1,7 +1,7 @@
 // RHGenericDriver.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHGenericDriver.h,v 1.19 2017/03/08 09:30:47 mikem Exp $
+// $Id: RHGenericDriver.h,v 1.20 2017/06/24 20:36:15 mikem Exp $
 
 #ifndef RHGenericDriver_h
 #define RHGenericDriver_h
@@ -303,6 +303,5 @@ protected:
 private:
 
 };
-
 
 #endif 

--- a/RHGenericDriver.h
+++ b/RHGenericDriver.h
@@ -206,7 +206,7 @@ public:
     /// Usually it is the RSSI of the last received message, which is measured when the preamble is received.
     /// If you called readRssi() more recently, it will return that more recent value.
     /// \return The most recent RSSI measurement in dBm.
-    int8_t        lastRssi();
+    int16_t        lastRssi();
 
     /// Returns the operating mode of the library.
     /// \return the current mode, one of RF69_MODE_*
@@ -283,7 +283,7 @@ protected:
     uint8_t             _txHeaderFlags;
 
     /// The value of the last received RSSI value, in some transport specific units
-    volatile int8_t     _lastRssi;
+    volatile int16_t     _lastRssi;
 
     /// Count of the number of bad messages (eg bad checksum etc) received
     volatile uint16_t   _rxBad;

--- a/RHGenericDriver.h
+++ b/RHGenericDriver.h
@@ -1,7 +1,7 @@
 // RHGenericDriver.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHGenericDriver.h,v 1.22 2017/10/03 06:04:59 mikem Exp mikem $
+// $Id: RHGenericDriver.h,v 1.22 2017/10/03 06:04:59 mikem Exp $
 
 #ifndef RHGenericDriver_h
 #define RHGenericDriver_h

--- a/RHGenericSPI.h
+++ b/RHGenericSPI.h
@@ -2,7 +2,7 @@
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2011 Mike McCauley
 // Contributed by Joanna Rutkowska
-// $Id: RHGenericSPI.h,v 1.7 2014/04/14 08:37:11 mikem Exp $
+// $Id: RHGenericSPI.h,v 1.8 2017/11/06 00:04:08 mikem Exp mikem $
 
 #ifndef RHGenericSPI_h
 #define RHGenericSPI_h

--- a/RHGenericSPI.h
+++ b/RHGenericSPI.h
@@ -7,7 +7,6 @@
 #ifndef RHGenericSPI_h
 #define RHGenericSPI_h
 
-#include <SPI.h> // for SPI_HAS_TRANSACTION and SPISettings
 #include <RadioHead.h>
 
 /////////////////////////////////////////////////////////////////////
@@ -125,7 +124,28 @@ public:
     /// \param[in] frequency The data rate to use: one of RHGenericSPI::Frequency
     virtual void setFrequency(Frequency frequency);
 
+    /// Signal the start of an SPI transaction that must not be interrupted by other SPI actions
+    /// In subclasses that support transactions this will ensure that other SPI transactions
+    /// are blocked until this one is completed by endTransaction().
+    /// Base does nothing
+    /// Might be overridden in subclass
+    virtual void beginTransaction(){}
+
+    /// Signal the end of an SPI transaction
+    /// Base does nothing
+    /// Might be overridden in subclass
+    virtual void endTransaction(){}
+
+    /// Specify the interrupt number of the interrupt that will use SPI transactions
+    /// Tells the SPI support software that SPI transactions will occur with the interrupt
+    /// handler assocated with interruptNumber
+    /// Base does nothing
+    /// Might be overridden in subclass
+    /// \param[in] interruptNumber The number of the interrupt
+    virtual void usingInterrupt(uint8_t interruptNumber){}
+    
 protected:
+    
     /// The configure SPI Bus frequency, one of RHGenericSPI::Frequency
     Frequency    _frequency; // Bus frequency, one of RHGenericSPI::Frequency
 
@@ -134,15 +154,5 @@ protected:
 
     /// SPI bus mode, one of RHGenericSPI::DataMode
     DataMode     _dataMode;  
-
-
-public:
-#if defined(SPI_HAS_TRANSACTION)
-    // An ugly hack... this probably belongs in RHHardwareSPI.cpp, but
-    // beginTransaction() needs to be called at a higher level which does
-    // not know if the underlying SPI is hardware or software.  This hack
-    // is merely for testing.
-    SPISettings  _settings;
-#endif
 };
 #endif

--- a/RHGenericSPI.h
+++ b/RHGenericSPI.h
@@ -2,7 +2,7 @@
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2011 Mike McCauley
 // Contributed by Joanna Rutkowska
-// $Id: RHGenericSPI.h,v 1.8 2017/11/06 00:04:08 mikem Exp mikem $
+// $Id: RHGenericSPI.h,v 1.8 2017/11/06 00:04:08 mikem Exp $
 
 #ifndef RHGenericSPI_h
 #define RHGenericSPI_h

--- a/RHHardwareSPI.cpp
+++ b/RHHardwareSPI.cpp
@@ -2,7 +2,7 @@
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2011 Mike McCauley
 // Contributed by Joanna Rutkowska
-// $Id: RHHardwareSPI.cpp,v 1.20 2018/02/11 23:57:18 mikem Exp mikem $
+// $Id: RHHardwareSPI.cpp,v 1.20 2018/02/11 23:57:18 mikem Exp $
 
 #include <RHHardwareSPI.h>
 
@@ -74,9 +74,10 @@ void RHHardwareSPI::begin()
    else
        frequency = 1000000;
 
-#if ((RH_PLATFORM == RH_PLATFORM_ARDUINO) && defined (__arm__) && (defined(ARDUINO_SAM_DUE) || defined(ARDUINO_ARCH_SAMD))) || defined(ARDUINO_ARCH_NRF52)
+#if ((RH_PLATFORM == RH_PLATFORM_ARDUINO) && defined (__arm__) && (defined(ARDUINO_SAM_DUE) || defined(ARDUINO_ARCH_SAMD))) || defined(ARDUINO_ARCH_NRF52) || defined(ARDUINO_ARCH_STM32F1) || defined(ARDUINO_ARCH_STM32F4)
     // Arduino Due in 1.5.5 has its own BitOrder :-(
     // So too does Arduino Zero
+    // So too does rogerclarkmelbourne/Arduino_STM32
     ::BitOrder bitOrder;
 #else
    uint8_t bitOrder;
@@ -130,9 +131,10 @@ void RHHardwareSPI::begin()
     SPI.setDataMode(dataMode);
 #endif
 
-#if ((RH_PLATFORM == RH_PLATFORM_ARDUINO) && defined (__arm__) && (defined(ARDUINO_SAM_DUE) || defined(ARDUINO_ARCH_SAMD))) || defined(ARDUINO_ARCH_NRF52)
+#if ((RH_PLATFORM == RH_PLATFORM_ARDUINO) && defined (__arm__) && (defined(ARDUINO_SAM_DUE) || defined(ARDUINO_ARCH_SAMD))) || defined(ARDUINO_ARCH_NRF52) || defined (ARDUINO_ARCH_STM32F1) || defined(ARDUINO_ARCH_STM32F4)
     // Arduino Due in 1.5.5 has its own BitOrder :-(
     // So too does Arduino Zero
+    // So too does rogerclarkmelbourne/Arduino_STM32
     ::BitOrder bitOrder;
 #else
     uint8_t bitOrder;
@@ -179,7 +181,6 @@ void RHHardwareSPI::begin()
 	    break;
 
     }
-
     SPI.setClockDivider(divider);
     SPI.begin();
     // Teensy requires it to be set _after_ begin()

--- a/RHHardwareSPI.cpp
+++ b/RHHardwareSPI.cpp
@@ -446,4 +446,3 @@ void RHHardwareSPI::usingInterrupt(uint8_t interrupt)
 }
 
 #endif
-

--- a/RHHardwareSPI.cpp
+++ b/RHHardwareSPI.cpp
@@ -2,7 +2,7 @@
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2011 Mike McCauley
 // Contributed by Joanna Rutkowska
-// $Id: RHHardwareSPI.cpp,v 1.18 2017/11/06 00:04:08 mikem Exp mikem $
+// $Id: RHHardwareSPI.cpp,v 1.19 2018/01/06 23:50:45 mikem Exp mikem $
 
 #include <RHHardwareSPI.h>
 

--- a/RHHardwareSPI.cpp
+++ b/RHHardwareSPI.cpp
@@ -2,7 +2,7 @@
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2011 Mike McCauley
 // Contributed by Joanna Rutkowska
-// $Id: RHHardwareSPI.cpp,v 1.16 2016/07/07 00:02:53 mikem Exp $
+// $Id: RHHardwareSPI.cpp,v 1.17 2017/07/25 05:26:50 mikem Exp mikem $
 
 #include <RHHardwareSPI.h>
 
@@ -284,7 +284,6 @@ void RHHardwareSPI::begin()
     SPI.begin(frequency, bitOrder, dataMode);
 
 #elif (RH_PLATFORM == RH_PLATFORM_STM32F2) // Photon
-    Serial.println("HERE");
     uint8_t dataMode;
     if (_dataMode == DataMode0)
 	dataMode = SPI_MODE0;

--- a/RHHardwareSPI.cpp
+++ b/RHHardwareSPI.cpp
@@ -1,8 +1,8 @@
-// RHHardwareSPI.h
+// RHHardwareSPI.cpp
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2011 Mike McCauley
 // Contributed by Joanna Rutkowska
-// $Id: RHHardwareSPI.cpp,v 1.19 2018/01/06 23:50:45 mikem Exp mikem $
+// $Id: RHHardwareSPI.cpp,v 1.20 2018/02/11 23:57:18 mikem Exp mikem $
 
 #include <RHHardwareSPI.h>
 
@@ -103,7 +103,7 @@ void RHHardwareSPI::begin()
    _settings = SPISettings(frequency, bitOrder, dataMode);
    SPI.begin();
 
-#else
+#else // SPI_HAS_TRANSACTION
 
     // Sigh: there are no common symbols for some of these SPI options across all platforms
 #if (RH_PLATFORM == RH_PLATFORM_ARDUINO) || (RH_PLATFORM == RH_PLATFORM_UNO32) || (RH_PLATFORM == RH_PLATFORM_CHIPKIT_CORE || RH_PLATFORM == RH_PLATFORM_NRF52)

--- a/RHHardwareSPI.cpp
+++ b/RHHardwareSPI.cpp
@@ -2,7 +2,7 @@
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2011 Mike McCauley
 // Contributed by Joanna Rutkowska
-// $Id: RHHardwareSPI.cpp,v 1.17 2017/07/25 05:26:50 mikem Exp mikem $
+// $Id: RHHardwareSPI.cpp,v 1.17 2017/07/25 05:26:50 mikem Exp $
 
 #include <RHHardwareSPI.h>
 
@@ -40,9 +40,7 @@ RHHardwareSPI::RHHardwareSPI(Frequency frequency, BitOrder bitOrder, DataMode da
 
 uint8_t RHHardwareSPI::transfer(uint8_t data) 
 {
-   uint8_t r = SPI.transfer(data);
-   //Serial.print("TX: "); Serial.print(data, HEX); Serial.print(" RX: "); Serial.println(r, HEX);
-   return r;
+    return SPI.transfer(data);
 }
 
 void RHHardwareSPI::attachInterrupt() 
@@ -61,34 +59,28 @@ void RHHardwareSPI::detachInterrupt()
     
 void RHHardwareSPI::begin() 
 {
-    // Sigh: there are no common symbols for some of these SPI options across all platforms
 #if defined(SPI_HAS_TRANSACTION)
-   uint32_t frequency32;
-   if (_frequency == Frequency16MHz) {
-       frequency32 = 16000000;
-   } else if (_frequency == Frequency8MHz) {
-       frequency32 = 8000000;
-   } else if (_frequency == Frequency4MHz) {
-       frequency32 = 4000000;
-   } else if (_frequency == Frequency2MHz) {
-       frequency32 = 2000000;
-   } else {
-       frequency32 = 1000000;
-   }
+    // Perhaps this is a uniform interface for SPI?
+    // Currently Teensy and ESP32 only
+   uint32_t frequency;
+   if (_frequency == Frequency16MHz)
+       frequency = 16000000;
+   else if (_frequency == Frequency8MHz)
+       frequency = 8000000;
+   else if (_frequency == Frequency4MHz)
+       frequency = 4000000;
+   else if (_frequency == Frequency2MHz)
+       frequency = 2000000;
+   else
+       frequency = 1000000;
 
-#if (RH_PLATFORM == RH_PLATFORM_ARDUINO) && defined (__arm__) && (defined(ARDUINO_SAM_DUE) || defined(ARDUINO_ARCH_SAMD)) || (RH_PLATFORM == RH_PLATFORM_NRF52)
-    // Arduino Due in 1.5.5 has its own BitOrder :-(
-    // So too does Arduino Zero and nRF52
-    ::BitOrder bOrder;
-  #else
-    uint8_t bOrder;
-  #endif
+   uint8_t bitOrder;
 
-   if (_bitOrder == BitOrderLSBFirst) {
-       bOrder = LSBFIRST;
-   } else {
-       bOrder = MSBFIRST;
-   }
+   if (_bitOrder == BitOrderLSBFirst)
+       bitOrder = LSBFIRST;
+   else
+       bitOrder = MSBFIRST;
+
     uint8_t dataMode;
     if (_dataMode == DataMode0)
 	dataMode = SPI_MODE0;
@@ -101,16 +93,13 @@ void RHHardwareSPI::begin()
     else
 	dataMode = SPI_MODE0;
 
-   _settings = SPISettings(frequency32, bOrder, dataMode);
-
-   //Serial.println("SPI has transactions");
+    // Save the settings for use in transactions
+   _settings = SPISettings(frequency, bitOrder, dataMode);
    SPI.begin();
+
 #else
-  #error "Only using transactions in this fork!"
-#endif
 
-   /*
-
+    // Sigh: there are no common symbols for some of these SPI options across all platforms
 #if (RH_PLATFORM == RH_PLATFORM_ARDUINO) || (RH_PLATFORM == RH_PLATFORM_UNO32) || (RH_PLATFORM == RH_PLATFORM_CHIPKIT_CORE)
     uint8_t dataMode;
     if (_dataMode == DataMode0)
@@ -420,13 +409,33 @@ void RHHardwareSPI::begin()
  #warning RHHardwareSPI does not support this platform yet. Consider adding it and contributing a patch.
 #endif
 
-   */
-
+#endif // SPI_HAS_TRANSACTION
 }
 
 void RHHardwareSPI::end() 
 {
     return SPI.end();
+}
+
+void RHHardwareSPI::beginTransaction()
+{
+#if defined(SPI_HAS_TRANSACTION)
+    SPI.beginTransaction(_settings);
+#endif
+}
+
+void RHHardwareSPI::endTransaction()
+{
+#if defined(SPI_HAS_TRANSACTION)
+    SPI.endTransaction();
+#endif
+}
+
+void RHHardwareSPI::usingInterrupt(uint8_t interrupt)
+{
+#if defined(SPI_HAS_TRANSACTION)
+
+#endif
 }
 
 #endif

--- a/RHHardwareSPI.h
+++ b/RHHardwareSPI.h
@@ -2,7 +2,7 @@
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2011 Mike McCauley
 // Contributed by Joanna Rutkowska
-// $Id: RHHardwareSPI.h,v 1.10 2017/01/12 23:58:00 mikem Exp $
+// $Id: RHHardwareSPI.h,v 1.11 2017/11/06 00:04:08 mikem Exp mikem $
 
 #ifndef RHHardwareSPI_h
 #define RHHardwareSPI_h

--- a/RHHardwareSPI.h
+++ b/RHHardwareSPI.h
@@ -7,8 +7,6 @@
 #ifndef RHHardwareSPI_h
 #define RHHardwareSPI_h
 
-#include <SPI.h>
-
 #include <RHGenericSPI.h>
 
 /////////////////////////////////////////////////////////////////////
@@ -17,6 +15,8 @@
 ///
 /// This concrete subclass of GenericSPIClass encapsulates the standard Arduino hardware and other
 /// hardware SPI interfaces.
+///
+/// SPI transactions are supported in development environments that support it with SPI_HAS_TRANSACTION.
 class RHHardwareSPI : public RHGenericSPI
 {
 #ifdef RH_HAVE_HARDWARE_SPI
@@ -60,6 +60,30 @@ public:
     void begin(){}
     void end(){}
 
+#endif
+
+    /// Signal the start of an SPI transaction that must not be interrupted by other SPI actions
+    /// In subclasses that support transactions this will ensure that other SPI transactions
+    /// are blocked until this one is completed by endTransaction().
+    /// Uses the underlying SPI transaction support if available as specified by SPI_HAS_TRANSACTION.
+    virtual void beginTransaction();
+
+    /// Signal the end of an SPI transaction
+    /// Uses the underlying SPI transaction support if available as specified by SPI_HAS_TRANSACTION.
+    virtual void endTransaction();
+
+    /// Specify the interrupt number of the interrupt that will use SPI transactions
+    /// Tells the SPI support software that SPI transactions will occur with the interrupt
+    /// handler assocated with interruptNumber
+    /// Uses the underlying SPI transaction support if available as specified by SPI_HAS_TRANSACTION.
+    /// \param[in] interruptNumber The number of the interrupt
+    virtual void usingInterrupt(uint8_t interruptNumber);
+
+protected:
+
+#if defined(SPI_HAS_TRANSACTION)
+    // Storage for SPI settings used in SPI transactions
+    SPISettings  _settings;
 #endif
 };
 

--- a/RHHardwareSPI.h
+++ b/RHHardwareSPI.h
@@ -2,7 +2,7 @@
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2011 Mike McCauley
 // Contributed by Joanna Rutkowska
-// $Id: RHHardwareSPI.h,v 1.11 2017/11/06 00:04:08 mikem Exp mikem $
+// $Id: RHHardwareSPI.h,v 1.11 2017/11/06 00:04:08 mikem Exp $
 
 #ifndef RHHardwareSPI_h
 #define RHHardwareSPI_h

--- a/RHMesh.cpp
+++ b/RHMesh.cpp
@@ -107,8 +107,8 @@ void RHMesh::peekAtMessage(RoutedMessage* message, uint8_t messageLen)
 	    if (d->route[i] == _thisAddress)
 		break;
 	i++;
-	while (i++ < numRoutes)
-	    addRouteTo(d->route[i], headerFrom());
+	while (i < numRoutes)
+	    addRouteTo(d->route[i++], headerFrom());
     }
     else if (   messageLen > 1 
 	     && m->msgType == RH_MESH_MESSAGE_TYPE_ROUTE_FAILURE)

--- a/RHMesh.h
+++ b/RHMesh.h
@@ -136,9 +136,9 @@ public:
     typedef struct
     {
 	MeshMessageHeader   header;  ///< msgType = RH_MESH_MESSAGE_TYPE_ROUTE_DISCOVERY_*
-	uint8_t             destlen; ///< Reserved. Must be 1.g
+	uint8_t             destlen; ///< Reserved. Must be 1
 	uint8_t             dest;    ///< The address of the destination node whose route is being sought
-	uint8_t             route[RH_MESH_MAX_MESSAGE_LEN - 1]; ///< List of node addresses visited so far. Length is implcit
+	uint8_t             route[RH_MESH_MAX_MESSAGE_LEN - 2]; ///< List of node addresses visited so far. Length is implcit
     } MeshRouteDiscoveryMessage;
 
     /// Signals a route failure

--- a/RHNRFSPIDriver.cpp
+++ b/RHNRFSPIDriver.cpp
@@ -32,9 +32,11 @@ uint8_t RHNRFSPIDriver::spiCommand(uint8_t command)
 {
     uint8_t status;
     ATOMIC_BLOCK_START;
+    _spi.beginTransaction();
     digitalWrite(_slaveSelectPin, LOW);
     status = _spi.transfer(command);
     digitalWrite(_slaveSelectPin, HIGH);
+    _spi.endTransaction();
     ATOMIC_BLOCK_END;
     return status;
 }
@@ -43,10 +45,12 @@ uint8_t RHNRFSPIDriver::spiRead(uint8_t reg)
 {
     uint8_t val;
     ATOMIC_BLOCK_START;
+    _spi.beginTransaction();
     digitalWrite(_slaveSelectPin, LOW);
     _spi.transfer(reg); // Send the address, discard the status
     val = _spi.transfer(0); // The written value is ignored, reg value is read
     digitalWrite(_slaveSelectPin, HIGH);
+    _spi.endTransaction();
     ATOMIC_BLOCK_END;
     return val;
 }
@@ -55,6 +59,7 @@ uint8_t RHNRFSPIDriver::spiWrite(uint8_t reg, uint8_t val)
 {
     uint8_t status = 0;
     ATOMIC_BLOCK_START;
+    _spi.beginTransaction();
     digitalWrite(_slaveSelectPin, LOW);
     status = _spi.transfer(reg); // Send the address
     _spi.transfer(val); // New value follows
@@ -65,6 +70,7 @@ uint8_t RHNRFSPIDriver::spiWrite(uint8_t reg, uint8_t val)
 delayMicroseconds(5);
 #endif
     digitalWrite(_slaveSelectPin, HIGH);
+    _spi.endTransaction();
     ATOMIC_BLOCK_END;
     return status;
 }
@@ -73,11 +79,13 @@ uint8_t RHNRFSPIDriver::spiBurstRead(uint8_t reg, uint8_t* dest, uint8_t len)
 {
     uint8_t status = 0;
     ATOMIC_BLOCK_START;
+    _spi.beginTransaction();
     digitalWrite(_slaveSelectPin, LOW);
     status = _spi.transfer(reg); // Send the start address
     while (len--)
 	*dest++ = _spi.transfer(0);
     digitalWrite(_slaveSelectPin, HIGH);
+    _spi.endTransaction();
     ATOMIC_BLOCK_END;
     return status;
 }
@@ -86,11 +94,13 @@ uint8_t RHNRFSPIDriver::spiBurstWrite(uint8_t reg, const uint8_t* src, uint8_t l
 {
     uint8_t status = 0;
     ATOMIC_BLOCK_START;
+    _spi.beginTransaction();
     digitalWrite(_slaveSelectPin, LOW);
     status = _spi.transfer(reg); // Send the start address
     while (len--)
 	_spi.transfer(*src++);
     digitalWrite(_slaveSelectPin, HIGH);
+    _spi.endTransaction();
     ATOMIC_BLOCK_END;
     return status;
 }
@@ -100,4 +110,8 @@ void RHNRFSPIDriver::setSlaveSelectPin(uint8_t slaveSelectPin)
     _slaveSelectPin = slaveSelectPin;
 }
 
+void RHNRFSPIDriver::spiUsingInterrupt(uint8_t interruptNumber)
+{
+    _spi.usingInterrupt(interruptNumber);
+}
 

--- a/RHNRFSPIDriver.cpp
+++ b/RHNRFSPIDriver.cpp
@@ -1,7 +1,7 @@
 // RHNRFSPIDriver.cpp
 //
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHNRFSPIDriver.cpp,v 1.4 2017/11/06 00:04:08 mikem Exp mikem $
+// $Id: RHNRFSPIDriver.cpp,v 1.4 2017/11/06 00:04:08 mikem Exp $
 
 #include <RHNRFSPIDriver.h>
 

--- a/RHNRFSPIDriver.cpp
+++ b/RHNRFSPIDriver.cpp
@@ -1,7 +1,7 @@
 // RHNRFSPIDriver.cpp
 //
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHNRFSPIDriver.cpp,v 1.3 2015/12/16 04:55:33 mikem Exp $
+// $Id: RHNRFSPIDriver.cpp,v 1.4 2017/11/06 00:04:08 mikem Exp mikem $
 
 #include <RHNRFSPIDriver.h>
 

--- a/RHNRFSPIDriver.h
+++ b/RHNRFSPIDriver.h
@@ -1,7 +1,7 @@
 // RHNRFSPIDriver.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHNRFSPIDriver.h,v 1.5 2017/11/06 00:04:08 mikem Exp mikem $
+// $Id: RHNRFSPIDriver.h,v 1.5 2017/11/06 00:04:08 mikem Exp $
 
 #ifndef RHNRFSPIDriver_h
 #define RHNRFSPIDriver_h

--- a/RHNRFSPIDriver.h
+++ b/RHNRFSPIDriver.h
@@ -1,7 +1,7 @@
 // RHNRFSPIDriver.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHNRFSPIDriver.h,v 1.4 2017/07/25 05:26:50 mikem Exp mikem $
+// $Id: RHNRFSPIDriver.h,v 1.4 2017/07/25 05:26:50 mikem Exp $
 
 #ifndef RHNRFSPIDriver_h
 #define RHNRFSPIDriver_h
@@ -83,6 +83,12 @@ public:
     /// pin that will be used for slave select in subsquent SPI operations.
     /// \param[in] slaveSelectPin The pin to use
     void setSlaveSelectPin(uint8_t slaveSelectPin);
+
+    /// Set the SPI interrupt number
+    /// If SPI transactions can occur within an interrupt, tell the low level SPI
+    /// interface which interrupt is used
+    /// \param[in] interruptNumber the interrupt number
+    void spiUsingInterrupt(uint8_t interruptNumber);
 
 protected:
     /// Reference to the RHGenericSPI instance to use to trasnfer data with teh SPI device

--- a/RHNRFSPIDriver.h
+++ b/RHNRFSPIDriver.h
@@ -1,7 +1,7 @@
 // RHNRFSPIDriver.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHNRFSPIDriver.h,v 1.4 2017/07/25 05:26:50 mikem Exp $
+// $Id: RHNRFSPIDriver.h,v 1.5 2017/11/06 00:04:08 mikem Exp mikem $
 
 #ifndef RHNRFSPIDriver_h
 #define RHNRFSPIDriver_h

--- a/RHNRFSPIDriver.h
+++ b/RHNRFSPIDriver.h
@@ -1,7 +1,7 @@
 // RHNRFSPIDriver.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHNRFSPIDriver.h,v 1.3 2015/12/16 04:55:33 mikem Exp $
+// $Id: RHNRFSPIDriver.h,v 1.4 2017/07/25 05:26:50 mikem Exp mikem $
 
 #ifndef RHNRFSPIDriver_h
 #define RHNRFSPIDriver_h
@@ -13,8 +13,8 @@ class RHGenericSPI;
 
 /////////////////////////////////////////////////////////////////////
 /// \class RHNRFSPIDriver RHNRFSPIDriver.h <RHNRFSPIDriver.h>
-/// \brief Base class for a RadioHead driver that use the SPI bus
-/// to communicate with its transport hardware.
+/// \brief Base class for RadioHead drivers that use the SPI bus
+/// to communicate with its NRF family transport hardware.
 ///
 /// This class can be subclassed by Drivers that require to use the SPI bus.
 /// It can be configured to use either the RHHardwareSPI class (if there is one available on the platform)

--- a/RHReliableDatagram.cpp
+++ b/RHReliableDatagram.cpp
@@ -9,7 +9,7 @@
 //
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2011 Mike McCauley
-// $Id: RHReliableDatagram.cpp,v 1.17 2017/03/08 09:30:47 mikem Exp mikem $
+// $Id: RHReliableDatagram.cpp,v 1.17 2017/03/08 09:30:47 mikem Exp $
 
 #include <RHReliableDatagram.h>
 

--- a/RHRouter.cpp
+++ b/RHRouter.cpp
@@ -9,7 +9,7 @@
 //
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2011 Mike McCauley
-// $Id: RHRouter.cpp,v 1.7 2015/08/13 02:45:47 mikem Exp $
+// $Id: RHRouter.cpp,v 1.8 2017/06/25 09:41:17 mikem Exp $
 
 #include <RHRouter.h>
 
@@ -198,6 +198,8 @@ uint8_t RHRouter::route(RoutedMessage* message, uint8_t messageLen)
 void RHRouter::peekAtMessage(RoutedMessage* message, uint8_t messageLen)
 {
     // Default does nothing
+  (void)message; // Not used
+  (void)messageLen; // Not used
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/RHRouter.h
+++ b/RHRouter.h
@@ -2,7 +2,7 @@
 //
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2011 Mike McCauley
-// $Id: RHRouter.h,v 1.9 2014/08/10 20:55:17 mikem Exp $
+// $Id: RHRouter.h,v 1.10 2017/07/25 05:26:50 mikem Exp mikem $
 
 #ifndef RHRouter_h
 #define RHRouter_h

--- a/RHRouter.h
+++ b/RHRouter.h
@@ -2,7 +2,7 @@
 //
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2011 Mike McCauley
-// $Id: RHRouter.h,v 1.10 2017/07/25 05:26:50 mikem Exp mikem $
+// $Id: RHRouter.h,v 1.10 2017/07/25 05:26:50 mikem Exp $
 
 #ifndef RHRouter_h
 #define RHRouter_h

--- a/RHRouter.h
+++ b/RHRouter.h
@@ -24,7 +24,7 @@
 #define RH_ROUTER_ERROR_UNABLE_TO_DELIVER 5
 
 // This size of RH_ROUTER_MAX_MESSAGE_LEN is OK for Arduino Mega, but too big for
-// Duemilanova. Size of 50 works with the sample router programs on Duemilanova.
+// Duemilanove. Size of 50 works with the sample router programs on Duemilanove.
 #define RH_ROUTER_MAX_MESSAGE_LEN (RH_MAX_MESSAGE_LEN - sizeof(RHRouter::RoutedMessageHeader))
 //#define RH_ROUTER_MAX_MESSAGE_LEN 50
 

--- a/RHSPIDriver.cpp
+++ b/RHSPIDriver.cpp
@@ -1,7 +1,7 @@
 // RHSPIDriver.cpp
 //
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHSPIDriver.cpp,v 1.10 2015/12/16 04:55:33 mikem Exp $
+// $Id: RHSPIDriver.cpp,v 1.11 2017/11/06 00:04:08 mikem Exp mikem $
 
 #include <RHSPIDriver.h>
 

--- a/RHSPIDriver.cpp
+++ b/RHSPIDriver.cpp
@@ -31,16 +31,10 @@ uint8_t RHSPIDriver::spiRead(uint8_t reg)
 {
     uint8_t val;
     ATOMIC_BLOCK_START;
-#if defined(SPI_HAS_TRANSACTION)
-    SPI.beginTransaction(_spi._settings);
-#endif
     digitalWrite(_slaveSelectPin, LOW);
     _spi.transfer(reg & ~RH_SPI_WRITE_MASK); // Send the address with the write mask off
     val = _spi.transfer(0); // The written value is ignored, reg value is read
     digitalWrite(_slaveSelectPin, HIGH);
-#if defined(SPI_HAS_TRANSACTION)
-    SPI.endTransaction();
-#endif
     ATOMIC_BLOCK_END;
     return val;
 }
@@ -49,16 +43,12 @@ uint8_t RHSPIDriver::spiWrite(uint8_t reg, uint8_t val)
 {
     uint8_t status = 0;
     ATOMIC_BLOCK_START;
-#if defined(SPI_HAS_TRANSACTION)
-    SPI.beginTransaction(_spi._settings);
-#endif
+    _spi.beginTransaction();
     digitalWrite(_slaveSelectPin, LOW);
     status = _spi.transfer(reg | RH_SPI_WRITE_MASK); // Send the address with the write mask on
     _spi.transfer(val); // New value follows
     digitalWrite(_slaveSelectPin, HIGH);
-#if defined(SPI_HAS_TRANSACTION)
-    SPI.endTransaction();
-#endif
+    _spi.endTransaction();
     ATOMIC_BLOCK_END;
     return status;
 }
@@ -67,17 +57,13 @@ uint8_t RHSPIDriver::spiBurstRead(uint8_t reg, uint8_t* dest, uint8_t len)
 {
     uint8_t status = 0;
     ATOMIC_BLOCK_START;
-#if defined(SPI_HAS_TRANSACTION)
-    SPI.beginTransaction(_spi._settings);
-#endif
+    _spi.beginTransaction();
     digitalWrite(_slaveSelectPin, LOW);
     status = _spi.transfer(reg & ~RH_SPI_WRITE_MASK); // Send the start address with the write mask off
     while (len--)
 	*dest++ = _spi.transfer(0);
     digitalWrite(_slaveSelectPin, HIGH);
-#if defined(SPI_HAS_TRANSACTION)
-    SPI.endTransaction();
-#endif
+    _spi.endTransaction();
     ATOMIC_BLOCK_END;
     return status;
 }
@@ -86,17 +72,13 @@ uint8_t RHSPIDriver::spiBurstWrite(uint8_t reg, const uint8_t* src, uint8_t len)
 {
     uint8_t status = 0;
     ATOMIC_BLOCK_START;
-#if defined(SPI_HAS_TRANSACTION)
-    SPI.beginTransaction(_spi._settings);
-#endif
+    _spi.beginTransaction();
     digitalWrite(_slaveSelectPin, LOW);
     status = _spi.transfer(reg | RH_SPI_WRITE_MASK); // Send the start address with the write mask on
     while (len--)
 	_spi.transfer(*src++);
     digitalWrite(_slaveSelectPin, HIGH);
-#if defined(SPI_HAS_TRANSACTION)
-    SPI.endTransaction();
-#endif
+    _spi.endTransaction();
     ATOMIC_BLOCK_END;
     return status;
 }
@@ -105,3 +87,9 @@ void RHSPIDriver::setSlaveSelectPin(uint8_t slaveSelectPin)
 {
     _slaveSelectPin = slaveSelectPin;
 }
+
+void RHSPIDriver::spiUsingInterrupt(uint8_t interruptNumber)
+{
+    _spi.usingInterrupt(interruptNumber);
+}
+

--- a/RHSPIDriver.cpp
+++ b/RHSPIDriver.cpp
@@ -1,7 +1,7 @@
 // RHSPIDriver.cpp
 //
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHSPIDriver.cpp,v 1.11 2017/11/06 00:04:08 mikem Exp mikem $
+// $Id: RHSPIDriver.cpp,v 1.11 2017/11/06 00:04:08 mikem Exp $
 
 #include <RHSPIDriver.h>
 

--- a/RHSPIDriver.h
+++ b/RHSPIDriver.h
@@ -1,7 +1,7 @@
 // RHSPIDriver.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHSPIDriver.h,v 1.10 2015/12/16 04:55:33 mikem Exp $
+// $Id: RHSPIDriver.h,v 1.11 2017/07/25 05:26:50 mikem Exp mikem $
 
 #ifndef RHSPIDriver_h
 #define RHSPIDriver_h
@@ -16,7 +16,7 @@ class RHGenericSPI;
 
 /////////////////////////////////////////////////////////////////////
 /// \class RHSPIDriver RHSPIDriver.h <RHSPIDriver.h>
-/// \brief Base class for a RadioHead drivers that use the SPI bus
+/// \brief Base class for RadioHead drivers that use the SPI bus
 /// to communicate with its transport hardware.
 ///
 /// This class can be subclassed by Drivers that require to use the SPI bus.

--- a/RHSPIDriver.h
+++ b/RHSPIDriver.h
@@ -1,7 +1,7 @@
 // RHSPIDriver.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHSPIDriver.h,v 1.11 2017/07/25 05:26:50 mikem Exp mikem $
+// $Id: RHSPIDriver.h,v 1.11 2017/07/25 05:26:50 mikem Exp $
 
 #ifndef RHSPIDriver_h
 #define RHSPIDriver_h
@@ -83,12 +83,19 @@ public:
     /// \param[in] slaveSelectPin The pin to use
     void setSlaveSelectPin(uint8_t slaveSelectPin);
 
+    /// Set the SPI interrupt number
+    /// If SPI transactions can occur within an interrupt, tell the low level SPI
+    /// interface which interrupt is used
+    /// \param[in] interruptNumber the interrupt number
+    void spiUsingInterrupt(uint8_t interruptNumber);
+
 protected:
     /// Reference to the RHGenericSPI instance to use to transfer data with teh SPI device
     RHGenericSPI&       _spi;
 
     /// The pin number of the Slave Select pin that is used to select the desired device.
     uint8_t             _slaveSelectPin;
+    uint8_t             _interuptPin; // If interrupts are used else NOT_AN_INTERRUPT
 };
 
 #endif

--- a/RHSPIDriver.h
+++ b/RHSPIDriver.h
@@ -1,7 +1,7 @@
 // RHSPIDriver.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHSPIDriver.h,v 1.12 2017/11/06 00:04:08 mikem Exp mikem $
+// $Id: RHSPIDriver.h,v 1.12 2017/11/06 00:04:08 mikem Exp $
 
 #ifndef RHSPIDriver_h
 #define RHSPIDriver_h

--- a/RHSPIDriver.h
+++ b/RHSPIDriver.h
@@ -1,7 +1,7 @@
 // RHSPIDriver.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHSPIDriver.h,v 1.13 2018/02/11 23:57:18 mikem Exp mikem $
+// $Id: RHSPIDriver.h,v 1.13 2018/02/11 23:57:18 mikem Exp $
 
 #ifndef RHSPIDriver_h
 #define RHSPIDriver_h

--- a/RHSPIDriver.h
+++ b/RHSPIDriver.h
@@ -1,7 +1,7 @@
 // RHSPIDriver.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHSPIDriver.h,v 1.11 2017/07/25 05:26:50 mikem Exp $
+// $Id: RHSPIDriver.h,v 1.12 2017/11/06 00:04:08 mikem Exp mikem $
 
 #ifndef RHSPIDriver_h
 #define RHSPIDriver_h

--- a/RHSPIDriver.h
+++ b/RHSPIDriver.h
@@ -1,7 +1,7 @@
 // RHSPIDriver.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RHSPIDriver.h,v 1.12 2017/11/06 00:04:08 mikem Exp $
+// $Id: RHSPIDriver.h,v 1.13 2018/02/11 23:57:18 mikem Exp mikem $
 
 #ifndef RHSPIDriver_h
 #define RHSPIDriver_h
@@ -90,7 +90,7 @@ public:
     void spiUsingInterrupt(uint8_t interruptNumber);
 
 protected:
-    /// Reference to the RHGenericSPI instance to use to transfer data with teh SPI device
+    /// Reference to the RHGenericSPI instance to use to transfer data with the SPI device
     RHGenericSPI&       _spi;
 
     /// The pin number of the Slave Select pin that is used to select the desired device.

--- a/RHSoftwareSPI.h
+++ b/RHSoftwareSPI.h
@@ -16,6 +16,8 @@
 /// Caution: this software SPI interface will be much slower than hardware SPI on most
 /// platforms.
 ///
+/// SPI transactions are not supported, and associated functions do nothing.
+///
 /// \par Usage
 ///
 /// Usage varies slightly depending on what driver you are using.

--- a/RH_ASK.cpp
+++ b/RH_ASK.cpp
@@ -1,14 +1,17 @@
 // RH_ASK.cpp
 //
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_ASK.cpp,v 1.22 2018/02/11 23:57:18 mikem Exp mikem $
+// $Id: RH_ASK.cpp,v 1.22 2018/02/11 23:57:18 mikem Exp $
 
 #include <RH_ASK.h>
 #include <RHCRC.h>
 
-#if (RH_PLATFORM == RH_PLATFORM_STM32) // Maple etc
+#if (RH_PLATFORM == RH_PLATFORM_STM32)
+    // Maple etc
 HardwareTimer timer(MAPLE_TIMER);
-
+#elif  defined(ARDUINO_ARCH_STM32F1) || defined(ARDUINO_ARCH_STM32F4)
+    // rogerclarkmelbourne/Arduino_STM32
+HardwareTimer timer(1);
 #endif
 
 #if (RH_PLATFORM == RH_PLATFORM_ESP8266)
@@ -175,6 +178,24 @@ void RH_ASK::timerSetup()
     TA0CTL = TASSEL_2 + MC_1;       // SMCLK, up mode
     TA0CCTL0 |= CCIE;               // CCR0 interrupt enabled
 
+#elif (RH_PLATFORM == RH_PLATFORM_STM32) || defined(ARDUINO_ARCH_STM32F1) || defined(ARDUINO_ARCH_STM32F4)
+    // Maple etc
+    // or rogerclarkmelbourne/Arduino_STM32
+    // Pause the timer while we're configuring it
+    timer.pause();
+    timer.setPeriod((1000000/8)/_speed);
+    // Set up an interrupt on channel 1
+    timer.setChannel1Mode(TIMER_OUTPUT_COMPARE);
+    timer.setCompare(TIMER_CH1, 1);  // Interrupt 1 count after each update
+    void interrupt(); // defined below
+    timer.attachCompare1Interrupt(interrupt);
+    
+    // Refresh the timer's count, prescale, and overflow
+    timer.refresh();
+    
+    // Start the timer counting
+    timer.resume();
+
 #elif (RH_PLATFORM == RH_PLATFORM_ARDUINO) // Arduino specific
     uint16_t nticks; // number of prescaled ticks needed
     uint8_t prescaler; // Bit values for CS0[2:0]
@@ -327,22 +348,6 @@ void RH_ASK::timerSetup()
    #endif // TIMSK1
   #endif
  #endif
-
-#elif (RH_PLATFORM == RH_PLATFORM_STM32) // Maple etc
-    // Pause the timer while we're configuring it
-    timer.pause();
-    timer.setPeriod((1000000/8)/_speed);
-    // Set up an interrupt on channel 1
-    timer.setChannel1Mode(TIMER_OUTPUT_COMPARE);
-    timer.setCompare(TIMER_CH1, 1);  // Interrupt 1 count after each update
-    void interrupt(); // defined below
-    timer.attachCompare1Interrupt(interrupt);
-    
-    // Refresh the timer's count, prescale, and overflow
-    timer.refresh();
-    
-    // Start the timer counting
-    timer.resume();
 
 #elif (RH_PLATFORM == RH_PLATFORM_STM32F2) // Photon
     // Inspired by SparkIntervalTimer
@@ -617,7 +622,12 @@ void TC1_Handler()
     TC_GetStatus(RH_ASK_DUE_TIMER, 1);
     thisASKDriver->handleTimerInterrupt();
 }
-
+#elif (RH_PLATFORM == RH_PLATFORM_ARDUINO) && defined(ARDUINO_ARCH_STM32F1) || defined(ARDUINO_ARCH_STM32F4)
+//rogerclarkmelbourne/Arduino_STM32
+void interrupt()
+{
+    thisASKDriver->handleTimerInterrupt();
+}
 #elif (RH_PLATFORM == RH_PLATFORM_ARDUINO) || (RH_PLATFORM == RH_PLATFORM_GENERIC_AVR8)
 // This is the interrupt service routine called when timer1 overflows
 // Its job is to output the next bit from the transmitter (every 8 calls)

--- a/RH_ASK.cpp
+++ b/RH_ASK.cpp
@@ -385,13 +385,19 @@ void RH_ASK::timerSetup()
     ConfigIntTimer1(T1_INT_ON | T1_INT_PRIOR_1);
 
 #elif (RH_PLATFORM == RH_PLATFORM_ESP8266)
-    void INTERRUPT_ATTR esp8266_timer_interrupt_handler(); // Forward declarat
+    void INTERRUPT_ATTR esp8266_timer_interrupt_handler(); // Forward declaration
     // The - 120 is a heuristic to correct for interrupt handling overheads
     _timerIncrement = (clockCyclesPerMicrosecond() * 1000000 / 8 / _speed) - 120;
     timer0_isr_init();
     timer0_attachInterrupt(esp8266_timer_interrupt_handler);
     timer0_write(ESP.getCycleCount() + _timerIncrement);
 //    timer0_write(ESP.getCycleCount() + 41660000);
+#elif (RH_PLATFORM == RH_PLATFORM_ESP32)
+    void IRAM_ATTR esp32_timer_interrupt_handler(); // Forward declaration
+    hw_timer_t * timer = timerBegin(0, 80, true); // Alarm value will be in in us
+    timerAttachInterrupt(timer, &esp32_timer_interrupt_handler, true);
+    timerAlarmWrite(timer, 1000000 / _speed / 8, true);
+    timerAlarmEnable(timer);
 #endif
 
 }
@@ -670,7 +676,11 @@ void INTERRUPT_ATTR esp8266_timer_interrupt_handler()
 //  digitalWrite(4, toggle);
     thisASKDriver->handleTimerInterrupt();
 }
-
+#elif (RH_PLATFORM == RH_PLATFORM_ESP32)
+void IRAM_ATTR esp32_timer_interrupt_handler()
+{
+    thisASKDriver->handleTimerInterrupt();
+}
 #endif
 
 // Convert a 6 bit encoded symbol into its 4 bit decoded equivalent

--- a/RH_ASK.cpp
+++ b/RH_ASK.cpp
@@ -1,7 +1,7 @@
 // RH_ASK.cpp
 //
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_ASK.cpp,v 1.20 2017/01/12 23:58:00 mikem Exp $
+// $Id: RH_ASK.cpp,v 1.21 2017/06/25 09:41:17 mikem Exp $
 
 #include <RH_ASK.h>
 #include <RHCRC.h>
@@ -47,8 +47,8 @@ RH_ASK::RH_ASK(uint16_t speed, uint8_t rxPin, uint8_t txPin, uint8_t pttPin, boo
     _rxPin(rxPin),
     _txPin(txPin),
     _pttPin(pttPin),
-    _pttInverted(pttInverted),
-    _rxInverted(false)
+    _rxInverted(false),
+    _pttInverted(pttInverted)
 {
     // Initialise the first 8 nibbles of the tx buffer to be the standard
     // preamble. We will append messages after that. 0x38, 0x2c is the start symbol before

--- a/RH_ASK.cpp
+++ b/RH_ASK.cpp
@@ -1,7 +1,7 @@
 // RH_ASK.cpp
 //
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_ASK.cpp,v 1.21 2017/06/25 09:41:17 mikem Exp $
+// $Id: RH_ASK.cpp,v 1.22 2018/02/11 23:57:18 mikem Exp mikem $
 
 #include <RH_ASK.h>
 #include <RHCRC.h>

--- a/RH_ASK.h
+++ b/RH_ASK.h
@@ -1,7 +1,7 @@
 // RH_ASK.h
 //
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_ASK.h,v 1.17 2017/03/04 00:59:41 mikem Exp $
+// $Id: RH_ASK.h,v 1.18 2017/07/25 05:26:50 mikem Exp mikem $
 
 #ifndef RH_ASK_h
 #define RH_ASK_h

--- a/RH_ASK.h
+++ b/RH_ASK.h
@@ -1,7 +1,7 @@
 // RH_ASK.h
 //
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_ASK.h,v 1.18 2017/07/25 05:26:50 mikem Exp mikem $
+// $Id: RH_ASK.h,v 1.18 2017/07/25 05:26:50 mikem Exp $
 
 #ifndef RH_ASK_h
 #define RH_ASK_h

--- a/RH_ASK.h
+++ b/RH_ASK.h
@@ -241,6 +241,13 @@
 /// library, when built for ATTiny85, takes over timer 0, which prevents use
 /// of millis() etc but does permit analog outputs. This will affect the accuracy of millis() and time
 /// measurement.
+///
+/// \par  STM32 F4 Discovery with Arduino and Arduino_STM32
+/// You can initialise the driver like this:
+/// \code
+/// RH_ASK driver(2000, PA3, PA4);
+/// \endcode
+/// and connect the serail to pins PA3 and PA4
 class RH_ASK : public RHGenericDriver
 {
 public:

--- a/RH_ASK.h
+++ b/RH_ASK.h
@@ -191,8 +191,10 @@
 /// If you run the chip at 1MHz, you will get RK_ASK speeds 1/8th of the expected.
 ///
 /// Initialise RH_ASK for ATTiny85 like this:
+/// \code
 /// // #include <SPI.h> // comment this out, not needed
 /// RH_ASK driver(2000, 4, 3); // 200bps, TX on D3 (pin 2), RX on D4 (pin 3)
+/// \endcode
 /// then:
 /// Connect D3 (pin 2) as the output to the transmitter
 /// Connect D4 (pin 3) as the input from the receiver.

--- a/RH_CC110.cpp
+++ b/RH_CC110.cpp
@@ -3,7 +3,7 @@
 // Driver for Texas Instruments CC110L transceiver.
 //
 // Copyright (C) 2016 Mike McCauley
-// $Id: RH_CC110.cpp,v 1.6 2017/07/25 05:26:50 mikem Exp mikem $
+// $Id: RH_CC110.cpp,v 1.7 2017/10/03 06:04:59 mikem Exp mikem $
 
 #include <RH_CC110.h>
 
@@ -86,6 +86,9 @@ bool RH_CC110::init()
 #ifdef RH_ATTACHINTERRUPT_TAKES_PIN_NUMBER
     interruptNumber = _interruptPin;
 #endif
+
+    // Tell the low level SPI interface we will use SPI within this interrupt
+    spiUsingInterrupt(interruptNumber);
 
     // Reset the chip
     // Strobe the reset

--- a/RH_CC110.cpp
+++ b/RH_CC110.cpp
@@ -3,7 +3,7 @@
 // Driver for Texas Instruments CC110L transceiver.
 //
 // Copyright (C) 2016 Mike McCauley
-// $Id: RH_CC110.cpp,v 1.5 2017/01/12 23:58:00 mikem Exp $
+// $Id: RH_CC110.cpp,v 1.6 2017/07/25 05:26:50 mikem Exp mikem $
 
 #include <RH_CC110.h>
 
@@ -159,8 +159,14 @@ void RH_CC110::handleInterrupt()
     {
 	// Radio is configured to stay in RX until we move it to IDLE after a CRC_OK message for us
 	// We only get interrupts in RX mode, on CRC_OK
-	// CRC OK
-	_lastRssi = spiBurstReadRegister(RH_CC110_REG_34_RSSI); // Was set when sync word was detected
+
+	uint8_t raw_rssi = spiBurstReadRegister(RH_CC110_REG_34_RSSI); // Was set when sync word was detected
+	// Conversion of RSSI value to received power level in dBm per TI section 5.18.2
+	if (raw_rssi >= 128) 
+	    _lastRssi = (((int16_t)raw_rssi - 256) / 2) - 74;
+	else 
+	    _lastRssi = ((int16_t)raw_rssi / 2) - 74;
+
 	_bufLen = spiReadRegister(RH_CC110_REG_3F_FIFO);
 	if (_bufLen < 4)
 	{

--- a/RH_CC110.cpp
+++ b/RH_CC110.cpp
@@ -3,7 +3,7 @@
 // Driver for Texas Instruments CC110L transceiver.
 //
 // Copyright (C) 2016 Mike McCauley
-// $Id: RH_CC110.cpp,v 1.9 2018/01/06 23:50:45 mikem Exp mikem $
+// $Id: RH_CC110.cpp,v 1.9 2018/01/06 23:50:45 mikem Exp $
 
 #include <RH_CC110.h>
 

--- a/RH_CC110.cpp
+++ b/RH_CC110.cpp
@@ -3,7 +3,7 @@
 // Driver for Texas Instruments CC110L transceiver.
 //
 // Copyright (C) 2016 Mike McCauley
-// $Id: RH_CC110.cpp,v 1.7 2017/10/03 06:04:59 mikem Exp mikem $
+// $Id: RH_CC110.cpp,v 1.8 2017/11/06 00:04:08 mikem Exp mikem $
 
 #include <RH_CC110.h>
 

--- a/RH_CC110.cpp
+++ b/RH_CC110.cpp
@@ -3,7 +3,7 @@
 // Driver for Texas Instruments CC110L transceiver.
 //
 // Copyright (C) 2016 Mike McCauley
-// $Id: RH_CC110.cpp,v 1.8 2017/11/06 00:04:08 mikem Exp mikem $
+// $Id: RH_CC110.cpp,v 1.9 2018/01/06 23:50:45 mikem Exp mikem $
 
 #include <RH_CC110.h>
 
@@ -345,6 +345,7 @@ bool RH_CC110::sleep()
 {
     if (_mode != RHModeSleep)
     {
+	spiCommand(RH_CC110_STROBE_36_SIDLE); //preceeding sleep IDLE first
 	spiCommand(RH_CC110_STROBE_39_SPWD);
 	_mode = RHModeSleep;
     }

--- a/RH_CC110.cpp
+++ b/RH_CC110.cpp
@@ -157,7 +157,7 @@ void RH_CC110::handleInterrupt()
 //    Serial.println("I");
     if (_mode == RHModeRx)
     {
-	// Radio is confgigured to stay in RX until we move it to IDLE after a CRC_OK message for us
+	// Radio is configured to stay in RX until we move it to IDLE after a CRC_OK message for us
 	// We only get interrupts in RX mode, on CRC_OK
 	// CRC OK
 	_lastRssi = spiBurstReadRegister(RH_CC110_REG_34_RSSI); // Was set when sync word was detected

--- a/RH_CC110.h
+++ b/RH_CC110.h
@@ -7,7 +7,7 @@
 // 
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2016 Mike McCauley
-// $Id: RH_CC110.h,v 1.5 2016/04/04 01:40:12 mikem Exp $
+// $Id: RH_CC110.h,v 1.6 2017/07/25 05:26:50 mikem Exp mikem $
 // 
 
 #ifndef RH_CC110_h
@@ -475,7 +475,7 @@
 
 /////////////////////////////////////////////////////////////////////
 /// \class RH_CC110 RH_CC110.h <RH_CC110.h>
-/// \brief Send and receive addressed, reliable, acknowledged datagrams by Texas Instruments CC110L and compatible transceivers and modules.
+/// \brief Send and receive unaddressed, unreliable, datagrams by Texas Instruments CC110L and compatible transceivers and modules.
 ///
 /// The TI CC110L is a low cost tranceiver chip capable of 300 to 928MHz and with a wide range of modulation types and speeds.
 /// The chip is typically provided on a module that also includes the antenna and coupling hardware
@@ -540,7 +540,7 @@
 /// a Chip Select pin and an Interrupt pin.
 /// Examples below assume the Anaren BoosterPack. Caution: the pin numbering on the Anaren BoosterPack
 /// is a bit counter-intuitive: the direction of number on J1 is the reverse of J2. Check the pin numbers
-/// stencilied on the front of the board to be sure.
+/// stenciled on the front of the board to be sure.
 ///
 /// \code
 ///                 Teensy 3.1   CC110L pin name         Anaren BoosterPack pin

--- a/RH_CC110.h
+++ b/RH_CC110.h
@@ -7,7 +7,7 @@
 // 
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2016 Mike McCauley
-// $Id: RH_CC110.h,v 1.7 2017/10/03 06:04:59 mikem Exp mikem $
+// $Id: RH_CC110.h,v 1.8 2017/11/06 00:04:08 mikem Exp mikem $
 // 
 
 #ifndef RH_CC110_h
@@ -800,6 +800,11 @@ public:
     /// \param[in] len Number of sync words to set. MUST be 2.
     void setSyncWords(const uint8_t* syncWords, uint8_t len);
 
+    /// Sets the PaTable registers directly.
+    /// Ensure you use suitable PATABLE values per Tbale 5-15 or 5-16
+    /// You may need to do this to implement an OOK modulation scheme.
+    void setPaTable(uint8_t* patable, uint8_t patablesize);
+
 protected:
     /// This is a low level function to handle the interrupts for one instance of RH_RF95.
     /// Called automatically by isr*()
@@ -842,10 +847,6 @@ protected:
     /// \return The value of the status byte per Table 5-2
     uint8_t statusRead();
 
-    /// Sets the PaTable registers directly.
-    /// Ensure you use suitable PATABLE values per Tbale 5-15 or 5-16
-    /// You may need to do this to implement an OOK modulation scheme.
-    void setPaTable(uint8_t* patable, uint8_t patablesize);
     
 private:
     /// Low level interrupt service routine for device connected to interrupt 0

--- a/RH_CC110.h
+++ b/RH_CC110.h
@@ -7,7 +7,7 @@
 // 
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2016 Mike McCauley
-// $Id: RH_CC110.h,v 1.6 2017/07/25 05:26:50 mikem Exp mikem $
+// $Id: RH_CC110.h,v 1.7 2017/10/03 06:04:59 mikem Exp mikem $
 // 
 
 #ifndef RH_CC110_h

--- a/RH_CC110.h
+++ b/RH_CC110.h
@@ -7,7 +7,7 @@
 // 
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2016 Mike McCauley
-// $Id: RH_CC110.h,v 1.8 2017/11/06 00:04:08 mikem Exp mikem $
+// $Id: RH_CC110.h,v 1.8 2017/11/06 00:04:08 mikem Exp $
 // 
 
 #ifndef RH_CC110_h

--- a/RH_E32.cpp
+++ b/RH_E32.cpp
@@ -170,7 +170,7 @@ void RH_E32::validateRxBuf()
     if (_bufLen < RH_E32_HEADER_LEN)
 	return; // Too short to be a real message
     if (_bufLen != _buf[0])
-      return false; // Do we have all the message?
+      return; // Do we have all the message?
     
     // Extract the 4 headers
     _rxHeaderTo    = _buf[1];

--- a/RH_E32.cpp
+++ b/RH_E32.cpp
@@ -1,7 +1,7 @@
 // RH_E32.cpp
 //
 // Copyright (C) 2017 Mike McCauley
-// $Id: RH_E32.cpp,v 1.1 2017/06/20 05:21:17 mikem Exp mikem $
+// $Id: RH_E32.cpp,v 1.2 2017/06/24 20:36:15 mikem Exp $
 
 #include <RH_E32.h>
 #include <Stream.h>

--- a/RH_E32.cpp
+++ b/RH_E32.cpp
@@ -1,0 +1,342 @@
+// RH_E32.cpp
+//
+// Copyright (C) 2017 Mike McCauley
+// $Id: RH_E32.cpp,v 1.1 2017/06/20 05:21:17 mikem Exp mikem $
+
+#include <RH_E32.h>
+#include <Stream.h>
+
+RH_E32::RH_E32(Stream *s, uint8_t m0_pin, uint8_t m1_pin, uint8_t aux_pin)
+  :
+  _s(s),
+  _m0_pin(m0_pin),
+  _m1_pin(m1_pin),
+  _aux_pin(aux_pin)
+{
+  // Prevent glitches at startup
+  pinMode(_aux_pin, INPUT);
+  digitalWrite(_m0_pin, true);
+  digitalWrite(_m1_pin, true);
+  pinMode(_m0_pin, OUTPUT);
+  pinMode(_m1_pin, OUTPUT);
+}
+
+bool RH_E32::init()
+{
+  // When a message is available, Aux will go low 5 msec before the first character is output
+  // So if we ever wait more than this period of time after Aux low, can conclude there will be no data
+  _s->setTimeout(10);
+
+  // Wait until the module is connected
+  waitAuxHigh();
+
+  if (!getVersion())
+      return false; // Could not communicate with module or wrong type of module
+  
+  setMode(RHModeRx);
+  clearRxBuf();
+
+  if (!setDataRate(DataRate5kbps))
+    return false;
+
+  if (!setPower(Power21dBm))
+    return false;
+
+  //  if (!setBaudRate(BaudRate9600, Parity8N1))
+  //  return false;
+
+  if (!setFrequency(433))
+    return false;
+  
+  return true;
+}
+
+bool RH_E32::reset()
+{
+  setOperatingMode(ModeSleep);
+  uint8_t resetCommand[] = { RH_E32_COMMAND_RESET, RH_E32_COMMAND_RESET, RH_E32_COMMAND_RESET };
+  size_t result = _s->write(resetCommand, sizeof(resetCommand));
+  setOperatingMode(ModeNormal);
+  return (result == sizeof(resetCommand));
+}
+
+bool RH_E32::readParameters(Parameters& params)
+{
+  setOperatingMode(ModeSleep);
+  uint8_t readParamsCommand[] = { RH_E32_COMMAND_READ_PARAMS, RH_E32_COMMAND_READ_PARAMS, RH_E32_COMMAND_READ_PARAMS };
+  _s->write(readParamsCommand, sizeof(readParamsCommand));
+  size_t result = _s->readBytes((char*)&params, sizeof(params)); // default 1 sec timeout
+  setOperatingMode(ModeNormal);
+  return (result == sizeof(Parameters));
+}
+
+bool RH_E32::writeParameters(Parameters& params, bool save)
+{
+  setOperatingMode(ModeSleep);
+  params.head = save ? RH_E32_COMMAND_WRITE_PARAMS_SAVE : RH_E32_COMMAND_WRITE_PARAMS_NOSAVE;
+  //  printBuffer("writing now", (uint8_t*)&params, sizeof(params));
+  size_t result = _s->write((char*)&params, sizeof(params));
+  if (result != sizeof(params))
+    return false;
+  
+  // Now we expect to get the same data back
+  result = _s->readBytes((char*)&params, sizeof(params));
+  if (result != sizeof(params))
+    return false;
+  //    printBuffer("additional read", (uint8_t*)&params, sizeof(params));
+  // Without a little delay here, writing params often fails
+  delay(20);
+  
+  setOperatingMode(ModeNormal);
+  return result == sizeof(params);
+}
+
+void RH_E32::setOperatingMode(OperatingMode mode)
+{
+  waitAuxHigh();
+  switch (mode)
+    {
+    case ModeNormal:
+      digitalWrite(_m0_pin, false);
+      digitalWrite(_m1_pin, false);
+      break;
+      
+    case ModeWakeUp:
+      digitalWrite(_m0_pin, true);
+      digitalWrite(_m1_pin, false);
+      break;
+      
+    case ModePowerSaving:
+      digitalWrite(_m0_pin, false);
+      digitalWrite(_m1_pin, true);
+      break;
+      
+    case ModeSleep:
+      digitalWrite(_m0_pin, true);
+      digitalWrite(_m1_pin, true);
+      break;
+      
+    }
+  delay(10); // Takes a little while to start its response
+  waitAuxHigh();
+}
+
+bool RH_E32::getVersion()
+{
+  setOperatingMode(ModeSleep);
+  uint8_t readVersionCommand[] = { RH_E32_COMMAND_READ_VERSION, RH_E32_COMMAND_READ_VERSION, RH_E32_COMMAND_READ_VERSION };
+  _s->write(readVersionCommand, sizeof(readVersionCommand));
+  uint8_t version[4];
+  size_t result = _s->readBytes(version, sizeof(version)); // default 1 sec timeout
+  setOperatingMode(ModeNormal);
+  if (result == 4)
+    {
+      // Successful read
+      //      printBuffer("read version", version, sizeof(version));
+      if (version[0] != 0xc3 || version [1] != 0x32)
+	{
+	  // Not an E32
+	  return false;
+	}
+      else
+	{
+	  // REVISIT: do something with it?
+	}
+    }
+  else
+    {
+      // Read failed: no module? Wrong baud?
+      return false;
+    }
+  return true;
+}
+
+void RH_E32::waitAuxHigh()
+{
+  // REVISIT: timeout needed?
+  while (digitalRead(_aux_pin) == false)
+    ;
+}
+
+void RH_E32::waitAuxLow()
+{
+  while (digitalRead(_aux_pin) == true)
+    ;
+}
+
+// Check whether the latest received message is complete and uncorrupted
+void RH_E32::validateRxBuf()
+{
+    if (_bufLen < RH_E32_HEADER_LEN)
+	return; // Too short to be a real message
+    if (_bufLen != _buf[0])
+      return false; // Do we have all the message?
+    
+    // Extract the 4 headers
+    _rxHeaderTo    = _buf[1];
+    _rxHeaderFrom  = _buf[2];
+    _rxHeaderId    = _buf[3];
+    _rxHeaderFlags = _buf[4];
+    if (_promiscuous ||
+	_rxHeaderTo == _thisAddress ||
+	_rxHeaderTo == RH_BROADCAST_ADDRESS)
+    {
+	_rxGood++;
+	_rxBufValid = true;
+    }
+}
+
+void RH_E32::clearRxBuf()
+{
+    _rxBufValid = false;
+    _bufLen = 0;
+}
+
+bool RH_E32::available()
+{
+    // Caution: long packets could be sent in several bursts
+    if (!_rxBufValid)
+    {
+	if (_mode == RHModeTx)
+	  return false;
+
+	if (!_s->available())
+	  return false;
+
+	// Suck up all the characters we can
+	uint8_t data;
+	while (_s->readBytes(&data, 1) == 1) // Not read timeout
+	  {
+	    _buf[_bufLen++] = data;
+	  }
+	// Now assess what we have
+	if (_bufLen < RH_E32_HEADER_LEN)
+	  {
+	    //	    Serial.println("Incomplete header");
+	    return false;
+	  }
+	else if (_bufLen < _buf[0])
+	  {
+	    //	    Serial.println("Incomplete message");
+	    return false;
+	  }
+	else if (   _bufLen > _buf[0]
+		 || _bufLen > RH_E32_MAX_PAYLOAD_LEN)
+	  {
+	    //	    Serial.println("Overrun");
+	    clearRxBuf();
+	    _rxBad++;
+	    return false;
+	  }
+
+	// Else it a partial or complete message, test it
+	//	printBuffer("read success", _buf, _bufLen);
+	validateRxBuf(); 
+    }
+    return _rxBufValid;
+}
+
+bool RH_E32::recv(uint8_t* buf, uint8_t* len)
+{
+    if (!available())
+	return false;
+    if (buf && len)
+    {
+	// Skip the 4 headers that are at the beginning of the rxBuf
+	if (*len > _bufLen - RH_E32_HEADER_LEN)
+	    *len = _bufLen - RH_E32_HEADER_LEN;
+	memcpy(buf, _buf + RH_E32_HEADER_LEN, *len);
+    }
+    clearRxBuf(); // This message accepted and cleared
+    return true;
+}
+
+bool RH_E32::send(const uint8_t* data, uint8_t len)
+{
+  if (len > RH_E32_MAX_MESSAGE_LEN)
+    return false;
+
+  waitPacketSent(); // Make sure we dont collide with previous message
+
+  // Set up the headers
+  _buf[0] = len + RH_E32_HEADER_LEN; // Number of octets in teh whole message
+  _buf[1] = _txHeaderTo;
+  _buf[2] = _txHeaderFrom;
+  _buf[3] = _txHeaderId;
+  _buf[4] = _txHeaderFlags;
+
+  // REVISIT: do we really have to do this? perhaps just write it after writing the header?
+  memcpy(_buf+RH_E32_HEADER_LEN, data, len);
+  
+  _s->write(_buf, len + RH_E32_HEADER_LEN);
+  setMode(RHModeTx);
+  _txGood++;
+  // Aux will return high when the TX buffer is empty
+  
+  return true;
+}
+
+uint8_t RH_E32::maxMessageLength()
+{
+  return RH_E32_MAX_MESSAGE_LEN;
+}
+
+bool RH_E32::waitPacketSent()
+{
+  if (_mode == RHModeTx)
+    waitAuxHigh();
+  setMode(RHModeRx);
+  return true;
+}
+
+bool RH_E32::setDataRate(DataRate rate)
+{
+  Parameters params;
+  if (!readParameters(params))
+    return false;
+  // The DataRate enums are the same values as the register bitmasks
+  params.sped &= ~RH_E32_PARAM_SPED_DATARATE_MASK;
+  params.sped |= (rate & RH_E32_PARAM_SPED_DATARATE_MASK);
+  return writeParameters(params);
+}
+
+bool RH_E32::setPower(PowerLevel level)
+{
+  Parameters params;
+  if (!readParameters(params))
+    return false;
+  // The DataRate enums are the same values as the register bitmasks
+  params.option &= ~RH_E32_PARAM_OPTION_POWER_MASK;
+  params.option |= (level & RH_E32_PARAM_OPTION_POWER_MASK);
+  return writeParameters(params);
+}
+
+bool RH_E32::setBaudRate(BaudRate rate, Parity parity)
+{
+  Parameters params;
+  if (!readParameters(params))
+    return false;
+  // The DataRate enums are the same values as the register bitmasks
+  params.sped &= ~RH_E32_PARAM_SPED_UART_BAUD_MASK;
+  params.sped |= (rate & RH_E32_PARAM_SPED_UART_BAUD_MASK);
+
+  // Also set the parity
+  params.sped &= ~RH_E32_PARAM_SPED_UART_MODE_MASK;
+  params.sped |= (parity & RH_E32_PARAM_SPED_UART_MODE_MASK);
+  
+  return writeParameters(params);
+}
+
+
+bool RH_E32::setFrequency(uint16_t frequency)
+{
+  if (frequency < 410 || frequency > 441)
+    return false;
+  
+  Parameters params;
+  if (!readParameters(params))
+    return false;
+  params.chan = frequency - 410;
+  return writeParameters(params);
+  
+}

--- a/RH_E32.cpp
+++ b/RH_E32.cpp
@@ -75,7 +75,7 @@ bool RH_E32::writeParameters(Parameters& params, bool save)
   setOperatingMode(ModeSleep);
   params.head = save ? RH_E32_COMMAND_WRITE_PARAMS_SAVE : RH_E32_COMMAND_WRITE_PARAMS_NOSAVE;
   //  printBuffer("writing now", (uint8_t*)&params, sizeof(params));
-  size_t result = _s->write((char*)&params, sizeof(params));
+  size_t result = _s->write((uint8_t*)&params, sizeof(params));
   if (result != sizeof(params))
     return false;
   
@@ -127,7 +127,7 @@ bool RH_E32::getVersion()
   uint8_t readVersionCommand[] = { RH_E32_COMMAND_READ_VERSION, RH_E32_COMMAND_READ_VERSION, RH_E32_COMMAND_READ_VERSION };
   _s->write(readVersionCommand, sizeof(readVersionCommand));
   uint8_t version[4];
-  size_t result = _s->readBytes(version, sizeof(version)); // default 1 sec timeout
+  size_t result = _s->readBytes((char *)version, sizeof(version)); // default 1 sec timeout
   setOperatingMode(ModeNormal);
   if (result == 4)
     {
@@ -205,7 +205,7 @@ bool RH_E32::available()
 
 	// Suck up all the characters we can
 	uint8_t data;
-	while (_s->readBytes(&data, 1) == 1) // Not read timeout
+	while (_s->readBytes((char *)&data, 1) == 1) // Not read timeout
 	  {
 	    _buf[_bufLen++] = data;
 	  }

--- a/RH_E32.h
+++ b/RH_E32.h
@@ -5,7 +5,7 @@
 //
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2017 Mike McCauley
-// $Id: RH_E32.h,v 1.4 2018/02/11 23:57:18 mikem Exp mikem $
+// $Id: RH_E32.h,v 1.4 2018/02/11 23:57:18 mikem Exp $
 // 
 
 #ifndef RH_E32_h

--- a/RH_E32.h
+++ b/RH_E32.h
@@ -1,0 +1,435 @@
+// RH_E32.h
+//
+// Definitions for E32-TTL-1W family serial radios:
+//  http://www.cdebyte.com/en/product-view-news.aspx?id=108
+//
+// Author: Mike McCauley (mikem@airspayce.com)
+// Copyright (C) 2017 Mike McCauley
+// $Id: RH_E32.h,v 1.1 2017/06/20 05:21:17 mikem Exp mikem $
+// 
+
+#ifndef RH_E32_h
+#define RH_E32_h
+
+#include <RHGenericDriver.h>
+
+// The buffer in the E32 is 512 bytes, but we arbitrarily limit messages to a maximum of 58 octets
+// We use some for headers, keeping fewer for RadioHead messages
+// The E32 sends messages longer than 58 octets in several packets of 58 octets each, and since we dont have any
+// framing or message level checksums there is a risk that long messages from 2 different sources
+// could be incorrectly interpreted as a single message
+#define RH_E32_MAX_PAYLOAD_LEN 58
+
+// The length of the headers we add:
+//  message length (including these headers)
+//  to
+//  from
+//  id
+//  flags
+// The headers are inside the E32 payload
+#define RH_E32_HEADER_LEN 5
+
+// This is the maximum RadioHead user message length that can be supported by this module. Limited by
+#define RH_E32_MAX_MESSAGE_LEN (RH_E32_MAX_PAYLOAD_LEN-RH_E32_HEADER_LEN)
+
+// Commands to alter module behaviour
+#define RH_E32_COMMAND_WRITE_PARAMS_SAVE         0xC0
+#define RH_E32_COMMAND_READ_PARAMS               0xC1
+#define RH_E32_COMMAND_WRITE_PARAMS_NOSAVE       0xC2
+#define RH_E32_COMMAND_READ_VERSION              0xC3
+#define RH_E32_COMMAND_RESET                     0xC4
+
+// Various flags and masks for param bytes
+#define RH_E32_PARAM_SPED_UART_MODE_MASK         0xC0
+#define RH_E32_PARAM_SPED_UART_MODE_8N1          0x00
+#define RH_E32_PARAM_SPED_UART_MODE_8O1          0x40
+#define RH_E32_PARAM_SPED_UART_MODE_8E1          0x80
+
+#define RH_E32_PARAM_SPED_UART_BAUD_MASK         0x38
+#define RH_E32_PARAM_SPED_UART_BAUD_1200         0x00
+#define RH_E32_PARAM_SPED_UART_BAUD_2400         0x08
+#define RH_E32_PARAM_SPED_UART_BAUD_4800         0x10
+#define RH_E32_PARAM_SPED_UART_BAUD_9600         0x18
+#define RH_E32_PARAM_SPED_UART_BAUD_19200        0x20
+#define RH_E32_PARAM_SPED_UART_BAUD_38400        0x28
+#define RH_E32_PARAM_SPED_UART_BAUD_57600        0x30
+#define RH_E32_PARAM_SPED_UART_BAUD_115200       0x38
+
+#define RH_E32_PARAM_SPED_DATARATE_MASK          0x07
+#define RH_E32_PARAM_SPED_DATARATE_1KBPS         0x00
+#define RH_E32_PARAM_SPED_DATARATE_2KBPS         0x01
+#define RH_E32_PARAM_SPED_DATARATE_5KBPS         0x02
+#define RH_E32_PARAM_SPED_DATARATE_8KBPS         0x03
+#define RH_E32_PARAM_SPED_DATARATE_10KBPS        0x04
+#define RH_E32_PARAM_SPED_DATARATE_15KBPS        0x05
+#define RH_E32_PARAM_SPED_DATARATE_20KBPS        0x06
+#define RH_E32_PARAM_SPED_DATARATE_25KBPS        0x07
+
+#define RH_E32_PARAM_OPTION_FIXED_MASK           0x80
+
+#define RH_E32_PARAM_OPTION_IODRIVE_MASK         0x40
+
+#define RH_E32_PARAM_OPTION_WAKEUP_TIME_MASK     0x38
+#define RH_E32_PARAM_OPTION_WAKEUP_TIME_250MS    0x00
+#define RH_E32_PARAM_OPTION_WAKEUP_TIME_500MS    0x08
+#define RH_E32_PARAM_OPTION_WAKEUP_TIME_750MS    0x10
+#define RH_E32_PARAM_OPTION_WAKEUP_TIME_1000MS   0x18
+#define RH_E32_PARAM_OPTION_WAKEUP_TIME_1250MS   0x20
+#define RH_E32_PARAM_OPTION_WAKEUP_TIME_1500MS   0x28
+#define RH_E32_PARAM_OPTION_WAKEUP_TIME_1750MS   0x30
+#define RH_E32_PARAM_OPTION_WAKEUP_TIME_2000MS   0x38
+
+#define RH_E32_PARAM_OPTION_FEC_MASK             0x04
+
+#define RH_E32_PARAM_OPTION_POWER_MASK           0x03
+#define RH_E32_PARAM_OPTION_POWER_30DBM          0x00
+#define RH_E32_PARAM_OPTION_POWER_27DBM          0x01
+#define RH_E32_PARAM_OPTION_POWER_24DBM          0x02
+#define RH_E32_PARAM_OPTION_POWER_21DBM          0x03
+
+/////////////////////////////////////////////////////////////////////
+/// \class RH_E32 RH_E32.h <RH_E32.h>
+/// \brief Driver to send and receive unaddressed, unreliable datagrams via a EBYTE E32-TTL-1W
+/// and similar serial radio transceiver.
+///
+/// Works with
+///  E32-TTL-1W
+///
+/// Note: it should also be possible to use the E32-TTL-1W with the RadioHead RH_Serial module,
+/// which will also you to send longer packets, but will require you to use the EBYTE Wireless Module Setting program
+/// to configure teh radio first. In this arrangement the E32 would act as a transparent serial connection.
+/// This has not been tested by us.
+///
+/// \par Overview
+///
+/// This class provides basic functions for sending and receiving unaddressed, 
+/// unreliable datagrams of arbitrary length to 53 octets per packet.
+///
+/// Manager classes may use this class to implement reliable, addressed datagrams and streams, 
+/// mesh routers, repeaters, translators etc.
+///
+/// Naturally, for any 2 radios to communicate that must be configured to use the same frequency and 
+/// modulation scheme.
+///
+/// This Driver provides an object-oriented interface for sending and receiving data messages with EBYTE
+/// RFM95/96/97/98(W), Semtech SX1276/77/78/7E32-TTL-1W9 and compatible radio modules. These modules implement
+/// long range LORA transcivers with a transparent serial interface. With 1W power output the manufacturer
+/// claims up to 6km range.
+///
+/// This Driver provides functions for sending and receiving messages of up
+/// to 53 octets on any frequency supported by the radio, in a range of
+/// data rates and power outputs. Frequency can be set with
+/// 1MHz precision to any frequency from 410 to 441MHz.
+///
+/// You can use either a hardware or software serial connection.
+///
+/// Tested with Arduino Uno and software serial.
+///
+/// \par Packet Format
+///
+/// All messages sent and received by this Driver conform to this packet format:
+///
+/// - 5 octets HEADER: (LENGTH,  TO, FROM, ID, FLAGS)
+/// - 0 to 53 octets DATA
+///
+/// \par Connecting E32-TTL-1W to Arduino
+///
+/// We tested with Arduino Uno. We used SoftwareSerial on pins 6 and 7) to connect to the E32 module, so
+/// we could continue to use the only hardware serial port for debugging
+/// \code
+///                 Arduino      RFM95/96/97/98
+///                 GND----------GND   (ground in)
+///                 5V-----------VCC   (5V in)
+///             pin D4-----------M0    (mode control pin input to radio)
+///             pin D5-----------M1    (mode control pin input to radio)
+///             pin D6-----------RXD   (serial data input from Arduino to radio)
+///             pin D7-----------TXD   (serial data output from radio to Arduino)
+///             pin D8-----------AUX   (Aux pin output from radio to Arduino)
+/// \endcode
+/// With this conneciton, you can initialise the serail port and RH_E32 like this:
+/// \code
+/// SoftwareSerial mySerial(7, 6);
+/// RH_E32  driver(&mySerial, 4, 5, 8);
+/// \endcode
+/// Other connection schems are possible provided the approporiate constructors are used for SoftwareSerial and RH_E32
+///
+/// \par Memory
+///
+/// The RH_RF95 driver requires non-trivial amounts of memory. The sample
+/// programs all compile to about 8kbytes each, which will fit in the
+/// flash proram memory of most Arduinos. However, the RAM requirements are
+/// more critical. Therefore, you should be vary sparing with RAM use in
+/// programs that use the RH_E32 driver.
+///
+/// It is often hard to accurately identify when you are hitting RAM limits on Arduino. 
+/// The symptoms can include:
+/// - Mysterious crashes and restarts
+/// - Changes in behaviour when seemingly unrelated changes are made (such as adding print() statements)
+/// - Hanging
+/// - Output from Serial.print() not appearing
+///
+/// \par Performance
+///
+/// This radio supports a range of different data rates and powers.
+/// The lowest speeds are the most reliable, however you should note that at 1kbps and with an 13 octet payload,
+/// the transmission time for one packet approaches 5 seconds. Therefore you should be cautios about trying to
+/// send too many or too long messages per unit of time, lest you monopolise the airwaves.
+/// Be a good neighbour and use the lowest power and fastest speed that you can.
+///
+/// \par Range
+///
+/// When running with a power output of 1W and at the slowest speed of 1kbps, this module has an impressive range.
+/// We tested with:
+///  E32-TTL-1W (1 W power, 1kbps data rate)
+///  Single wire antenna with a small meta ground plane at about 1m above ground level
+///  Arduino Uno
+///  RadioHead RH_E32 module with e32_client and e32_server sketches
+///  Packet length 13 octets (total payload 18 octets)
+///  (and yes, we have an appropriate radio license for that power output)
+///
+/// We were able to get reliable reception over 7km (6 km over ocean and 1 km through low rise residential area)
+///
+/// You can expect less range with lower power outputs and faster speeds.
+/// You can expect less range in highrise cities.
+/// You can expect more range with directional antennas.
+/// You can expect more range with shorter messages.
+/// 
+/// \par Transmitter Power
+///   TBA
+///
+/// Caution: the maximum power output of this radio (1W = 30dbM) is almost certainly more than the
+/// permitted power level for unlicensed users in the ISM bands in most countries. Be sure you comply with your local
+/// regulations. Be a good neighbour and use the lowest power and fastest speed that you can.
+///
+class Stream;
+class RH_E32 : public RHGenericDriver
+{
+ public:
+
+    /// \brief Values to be passed to setDataRate() to control the on-air data rate
+    ///
+    /// This is NOT to be used to control the baud rate of the serial connection to the radio
+    typedef enum
+    {
+      DataRate1kbps  = RH_E32_PARAM_SPED_DATARATE_1KBPS,
+      DataRate2kbps  = RH_E32_PARAM_SPED_DATARATE_2KBPS,
+      DataRate5kbps  = RH_E32_PARAM_SPED_DATARATE_5KBPS,
+      DataRate8kbps  = RH_E32_PARAM_SPED_DATARATE_8KBPS,
+      DataRate10kbps = RH_E32_PARAM_SPED_DATARATE_10KBPS,
+      DataRate15kbps = RH_E32_PARAM_SPED_DATARATE_15KBPS,
+      DataRate20kbps = RH_E32_PARAM_SPED_DATARATE_20KBPS,
+      DataRate25kbps = RH_E32_PARAM_SPED_DATARATE_25KBPS
+    } DataRate;
+    
+    /// \brief Values to be passed to setPower() to control the transmitter power
+    ///
+    typedef enum
+    {
+      Power30dBm = RH_E32_PARAM_OPTION_POWER_30DBM,
+      Power27dBm = RH_E32_PARAM_OPTION_POWER_27DBM,
+      Power24dBm = RH_E32_PARAM_OPTION_POWER_24DBM,
+      Power21dBm = RH_E32_PARAM_OPTION_POWER_21DBM,
+    } PowerLevel;
+
+    /// \brief Values to be passed to setBaudRate() to control the radio serial connection baud rate
+    ///
+    /// This is NOT to be used to control the on-air data rate the radio transmits and receives at
+    typedef enum
+    {
+      BaudRate1200   = RH_E32_PARAM_SPED_UART_BAUD_1200,
+      BaudRate2400   = RH_E32_PARAM_SPED_UART_BAUD_2400,
+      BaudRate4800   = RH_E32_PARAM_SPED_UART_BAUD_4800,
+      BaudRate9600   = RH_E32_PARAM_SPED_UART_BAUD_9600,
+      BaudRate19200  = RH_E32_PARAM_SPED_UART_BAUD_19200,
+      BaudRate38400  = RH_E32_PARAM_SPED_UART_BAUD_38400,
+      BaudRate57600  = RH_E32_PARAM_SPED_UART_BAUD_57600,
+      BaudRate115200 = RH_E32_PARAM_SPED_UART_BAUD_115200,
+    } BaudRate;
+
+    /// \brief Values to be passed to setBaudRate() to control the parity of the serial connection to the radio
+    typedef enum
+    {
+      Parity8N1 = RH_E32_PARAM_SPED_UART_MODE_8N1,
+      Parity8O1 = RH_E32_PARAM_SPED_UART_MODE_8O1,
+      Parity8E1 = RH_E32_PARAM_SPED_UART_MODE_8E1,
+    } Parity;
+ 
+    /// Contructor. You can have multiple instances, but each instance must have its own
+    /// serial connection, M0 M1 and AUX connections. Initialises the mode of the referenced pins
+    /// Does NOT set the baud rate of the serial connection to the radio.
+    /// \param[in] s Reference to the SoftwareSerial or HardwareSerial port used to connect to the radio
+    /// \param[in] m0_pin Pin number of the Arduino pin that connects to the radio M0 input
+    /// \param[in] m1_pin Pin number of the Arduino pin that connects to the radio M1 input
+    /// \param[in] aux_pin Pin number of the Arduino pin that connects to the radio AUX output
+    RH_E32(Stream *s=&Serial, uint8_t m0_pin = 4, uint8_t m1_pin = 5, uint8_t aux_pin = 8);
+
+    /// Initialise the Driver transport hardware and software.
+    /// Make sure the Driver is properly, including setting the serial port baud rate and parity to that
+    /// configured in the radio (typically 9600 baud, 8N1) before calling init().
+    /// Sets the module to 443MHz, 21dBm power and 5kbps data rate (you can change these after initialisation with
+    /// the various set* functions).
+    /// This function may not return if the AUX pin is not connected.
+    /// Initialisation failure can be caused by:
+    /// Electrical connections to the radio incorrect or incomplete
+    /// Radio configured to use a different baud rate to the one configured to the Ardiono serial port
+    /// Incorrect radio module connected tot he serial port.
+    /// Other serial communicaitons problems between the Arduino and the radio
+    /// \return true if initialisation succeeded.
+    bool init();
+
+    /// Tests whether a new message is available
+    /// from the Driver. 
+    /// This can and should be called multiple times in a timeout loop. You should call this as frequently as possible
+    /// whenever a message might be received
+    /// \return true if a new, complete, error-free uncollected message is available to be retreived by recv().
+    bool available();
+    
+    /// If there is a valid message available, copy it to buf and return true
+    /// else return false.
+    /// If a message is copied, *len is set to the length (Caution, 0 length messages are permitted).
+    /// You should be sure to call this function frequently enough to not miss any messages
+    /// It is recommended that you call it in your main loop.
+    /// \param[in] buf Location to copy the received message
+    /// \param[in,out] len Pointer to available space in buf. Set to the actual number of octets copied.
+    /// \return true if a valid message was copied to buf
+    bool recv(uint8_t* buf, uint8_t* len);
+    
+    /// Waits until any previous transmit packet is finished being transmitted with waitPacketSent().
+    /// Then loads a message into the transmitter and starts the transmitter. Note that a message length
+    /// of 0 is permitted. 
+    /// \param[in] data Array of data to be sent
+    /// \param[in] len Number of bytes of data to send
+    /// \return true if the message length was valid and it was correctly queued for transmit. Return false
+    /// if CAD was requested and the CAD timeout timed out before clear channel was detected.
+    bool send(const uint8_t* data, uint8_t len);
+    
+    /// Returns the maximum message length 
+    /// available in this Driver.
+    /// \return The maximum legal message length
+    uint8_t maxMessageLength();
+
+    /// Waits for any currently transmitting packet to be completely sent
+    /// Returns true if successful
+    bool waitPacketSent();
+
+    /// Sets the on-air data rate to be used by the transmitter and receiver
+    /// \param[in] rate A valid data rate from the DataRate enum
+    /// \return true if successful
+    bool setDataRate(DataRate rate);
+    
+    /// Sets the transmitter power output
+    /// \param[in] level A valid power setting from the Power enum
+    /// \return true if successful
+    bool setPower(PowerLevel level);
+    
+    /// Sets the radio serial port baud rate and parity (not the on-air data rate)
+    /// Does not set the Aruino rate or parity: you wil nned to do this afterwards
+    /// \param[in] rate A valid baud rate from the BaudRate enum
+    /// \param[in] parity A valid parity from the PArity enum
+    /// \return true if successful
+    bool setBaudRate(BaudRate rate = BaudRate9600, Parity parity = Parity8N1);
+
+    /// Sets the tarnsmitter and receiver frequency.
+    /// \param[in] frequency Desired frequency in MHx from 410 to 441 MHz inclusive
+    /// \return true if successful
+    bool setFrequency(uint16_t frequency);
+ 
+protected:
+
+    /// \brief Defines values to be passed to setOperatinMode
+    ///
+    /// For internal driver user only
+    typedef enum
+    {
+      ModeNormal = 0,    ///< Normal mode for sending and receiving messages
+      ModeWakeUp,        ///< Adds a long preamble to transmission to allow destination receivers to wake up
+      ModePowerSaving,   ///< Receiver sleeps until a message is received
+      ModeSleep          ///< Use during parameter setting
+    } OperatingMode;
+    
+    /// \brief Structure for reading and writing radio control parameters
+    ///
+    /// For internal driver user only
+    typedef struct
+    {
+      uint8_t head;      ///< 0xc2 (no save) or 0xc0 (save)
+      uint8_t addh;      ///< High address byte (not used by this driver)
+      uint8_t addl;      ///< Low address byte (not used by this driver)
+      uint8_t sped;      ///< Data and baud rate parameters
+      uint8_t chan;      ///< Radio channel
+      uint8_t option;    ///< Various control options
+      
+    } Parameters;
+
+    /// Sets the operating mode of the radio.
+    /// For internal use only
+    void setOperatingMode(OperatingMode mode);
+
+    /// Retrieves the version number for the radio and checks that it is valid
+    /// \return true if the version could be retrieved and is radio model number is correct
+    bool getVersion();
+
+    /// Waits for the AUX pin to go high
+    /// For internal use only
+    void waitAuxHigh();
+
+    /// Waits for the AUX pin to go low
+    /// For internal use only
+    void waitAuxLow();
+    
+    /// Issues a reset command to the radio
+    /// WARNING: this seems to break reception. Why?
+    /// \return true if successful
+    bool reset();
+
+    /// Read the radio configuration parameters into
+    /// local memory
+    /// \param[in] params Reference to a Parameter structure which will be filled if successful
+    /// \return true if successful
+    bool readParameters(Parameters& params);
+
+    /// Write radio configuration parameters from local memory
+    /// to the radio. You can choose whether the parameter will be saved across power down or not
+    /// \param[in] params Reference to a Parameter structure containing the radio configuration paramerters
+    /// to be written to the radio.
+    /// \param[in] save If true, the parameters will be saved across power down in the radio
+    /// \return true if successful
+    bool writeParameters(Parameters& params, bool save = false);
+
+    /// Examine the receive buffer to determine whether the message is for this node
+    /// For internal use only
+    void validateRxBuf();
+
+    /// Clear our local receive buffer
+    /// For internal use only
+    void clearRxBuf();
+
+private:
+    /// Serial stream (hardware or software serial)
+    Stream*     _s;
+
+    /// Pin number connected to M0
+    uint8_t     _m0_pin;
+
+    /// Pin number connected to M1
+    uint8_t     _m1_pin;
+
+    /// Pin number connected to AUX
+    uint8_t     _aux_pin;
+    
+    /// Number of octets in the buffer
+    uint8_t             _bufLen;
+    
+    /// The receiver/transmitter buffer
+    uint8_t             _buf[RH_E32_MAX_PAYLOAD_LEN];
+
+    /// True when there is a valid message in the buffer
+    bool                _rxBufValid;
+
+};
+
+/// @example e32_client.pde
+/// @example e32_server.pde
+
+#endif
+

--- a/RH_E32.h
+++ b/RH_E32.h
@@ -392,7 +392,7 @@ protected:
 
     /// Write radio configuration parameters from local memory
     /// to the radio. You can choose whether the parameter will be saved across power down or not
-    /// \param[in] params Reference to a Parameter structure containing the radio configuration paramerters
+    /// \param[in] params Reference to a Parameter structure containing the radio configuration parameters
     /// to be written to the radio.
     /// \param[in] save If true, the parameters will be saved across power down in the radio
     /// \return true if successful

--- a/RH_E32.h
+++ b/RH_E32.h
@@ -176,6 +176,8 @@
 /// send too many or too long messages per unit of time, lest you monopolise the airwaves.
 /// Be a good neighbour and use the lowest power and fastest speed that you can.
 ///
+/// Forward Error Correction (FEC) is always enabled in these radios by RH_E32.
+///
 /// \par Range
 ///
 /// When running with a power output of 1W and at the slowest speed of 1kbps, this module has an impressive range.

--- a/RH_E32.h
+++ b/RH_E32.h
@@ -5,7 +5,7 @@
 //
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2017 Mike McCauley
-// $Id: RH_E32.h,v 1.3 2018/01/06 23:50:45 mikem Exp mikem $
+// $Id: RH_E32.h,v 1.4 2018/02/11 23:57:18 mikem Exp mikem $
 // 
 
 #ifndef RH_E32_h
@@ -137,7 +137,7 @@
 /// We tested with Arduino Uno. We used SoftwareSerial on pins 6 and 7) to connect to the E32 module, so
 /// we could continue to use the only hardware serial port for debugging
 /// \code
-///                 Arduino      RFM95/96/97/98
+///                 Arduino      E32
 ///                 GND----------GND   (ground in)
 ///                 5V-----------VCC   (5V in)
 ///             pin D4-----------M0    (mode control pin input to radio)
@@ -146,10 +146,26 @@
 ///             pin D7-----------TXD   (serial data output from radio to Arduino)
 ///             pin D8-----------AUX   (Aux pin output from radio to Arduino)
 /// \endcode
-/// With this conneciton, you can initialise the serail port and RH_E32 like this:
+/// With this connection, you can initialise the serial port and RH_E32 like this:
 /// \code
 /// SoftwareSerial mySerial(7, 6);
 /// RH_E32  driver(&mySerial, 4, 5, 8);
+/// \endcode
+///
+/// For Adafruit M0 Feather:
+/// \code
+///                 Feather      E32
+///                 GND----------GND   (ground in)
+///                 3V-----------VCC   (3.3V in)
+///             pin D5-----------M0    (mode control pin input to radio)
+///             pin D6-----------M1    (mode control pin input to radio)
+///             pin D1/Tx--------RXD   (serial data input from M0 to radio)
+///             pin D0/Rx--------TXD   (serial data output from radio to M0)
+///             pin D9-----------AUX   (Aux pin output from radio to M0)
+/// \endcode
+/// With this connection, you can initialise serial port 1 and RH_E32 like this:
+/// \code
+/// RH_E32  driver(&Serial1, 5, 6, 9);
 /// \endcode
 /// Other connection schems are possible provided the approporiate constructors are used for SoftwareSerial and RH_E32
 ///

--- a/RH_E32.h
+++ b/RH_E32.h
@@ -5,7 +5,7 @@
 //
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2017 Mike McCauley
-// $Id: RH_E32.h,v 1.1 2017/06/20 05:21:17 mikem Exp mikem $
+// $Id: RH_E32.h,v 1.2 2017/06/24 20:36:15 mikem Exp $
 // 
 
 #ifndef RH_E32_h

--- a/RH_E32.h
+++ b/RH_E32.h
@@ -5,7 +5,7 @@
 //
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2017 Mike McCauley
-// $Id: RH_E32.h,v 1.2 2017/06/24 20:36:15 mikem Exp $
+// $Id: RH_E32.h,v 1.3 2018/01/06 23:50:45 mikem Exp mikem $
 // 
 
 #ifndef RH_E32_h
@@ -97,7 +97,7 @@
 ///
 /// Note: it should also be possible to use the E32-TTL-1W with the RadioHead RH_Serial module,
 /// which will also you to send longer packets, but will require you to use the EBYTE Wireless Module Setting program
-/// to configure teh radio first. In this arrangement the E32 would act as a transparent serial connection.
+/// to configure the radio first. In this arrangement the E32 would act as a transparent serial connection.
 /// This has not been tested by us.
 ///
 /// \par Overview

--- a/RH_MRF89.cpp
+++ b/RH_MRF89.cpp
@@ -67,6 +67,9 @@ bool RH_MRF89::init()
     interruptNumber = _interruptPin;
 #endif
 
+    // Tell the low level SPI interface we will use SPI within this interrupt
+    spiUsingInterrupt(interruptNumber);
+
     // Make sure we are not in some unexpected mode from a previous run    
     setOpMode(RH_MRF89_CMOD_STANDBY); 
 
@@ -286,10 +289,12 @@ uint8_t RH_MRF89::spiWriteData(const uint8_t* data, uint8_t len)
 
     uint8_t status = 0;
     ATOMIC_BLOCK_START;
+    _spi.beginTransaction();
     digitalWrite(_slaveSelectPin, LOW);
     while (len--)
 	_spi.transfer(*data++);
     digitalWrite(_slaveSelectPin, HIGH);
+    _spi.endTransaction();
     ATOMIC_BLOCK_END;
     return status;
 

--- a/RH_MRF89.cpp
+++ b/RH_MRF89.cpp
@@ -1,7 +1,7 @@
 // RH_MRF89.cpp
 //
 // Copyright (C) 2015 Mike McCauley
-// $Id: RH_MRF89.cpp,v 1.9 2017/11/06 00:04:08 mikem Exp mikem $
+// $Id: RH_MRF89.cpp,v 1.9 2017/11/06 00:04:08 mikem Exp $
 
 #include <RH_MRF89.h>
 #define BAND_915

--- a/RH_MRF89.cpp
+++ b/RH_MRF89.cpp
@@ -1,7 +1,7 @@
 // RH_MRF89.cpp
 //
 // Copyright (C) 2015 Mike McCauley
-// $Id: RH_MRF89.cpp,v 1.8 2017/01/12 23:58:00 mikem Exp $
+// $Id: RH_MRF89.cpp,v 1.9 2017/11/06 00:04:08 mikem Exp mikem $
 
 #include <RH_MRF89.h>
 #define BAND_915

--- a/RH_MRF89.h
+++ b/RH_MRF89.h
@@ -6,7 +6,7 @@
 //
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2015 Mike McCauley
-// $Id: RH_MRF89.h,v 1.6 2015/12/17 10:58:13 mikem Exp $
+// $Id: RH_MRF89.h,v 1.7 2017/07/25 05:26:50 mikem Exp mikem $
 // 
 
 #ifndef RH_RF95_h
@@ -311,7 +311,7 @@
 
 /////////////////////////////////////////////////////////////////////
 /// \class RH_MRF89 RH_MRF89.h <RH_MRF89.h>
-/// \brief Send and receive addressed, reliable, acknowledged datagrams by Microchip MRF89XA and compatible transceivers.
+/// \brief Send and receive unaddressed, unreliable datagrams by Microchip MRF89XA and compatible transceivers.
 /// and modules.
 ///
 /// The Microchip MRF89XA http://ww1.microchip.com/downloads/en/DeviceDoc/70622C.pdf is a low cost 900MHz

--- a/RH_MRF89.h
+++ b/RH_MRF89.h
@@ -6,7 +6,7 @@
 //
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2015 Mike McCauley
-// $Id: RH_MRF89.h,v 1.7 2017/07/25 05:26:50 mikem Exp mikem $
+// $Id: RH_MRF89.h,v 1.7 2017/07/25 05:26:50 mikem Exp $
 // 
 
 #ifndef RH_RF95_h

--- a/RH_NRF24.cpp
+++ b/RH_NRF24.cpp
@@ -1,7 +1,7 @@
 // NRF24.cpp
 //
 // Copyright (C) 2012 Mike McCauley
-// $Id: RH_NRF24.cpp,v 1.24 2017/06/20 05:21:17 mikem Exp mikem $
+// $Id: RH_NRF24.cpp,v 1.24 2017/06/20 05:21:17 mikem Exp $
 
 #include <RH_NRF24.h>
 

--- a/RH_NRF24.cpp
+++ b/RH_NRF24.cpp
@@ -1,7 +1,7 @@
 // NRF24.cpp
 //
 // Copyright (C) 2012 Mike McCauley
-// $Id: RH_NRF24.cpp,v 1.25 2017/07/25 05:26:50 mikem Exp mikem $
+// $Id: RH_NRF24.cpp,v 1.25 2017/07/25 05:26:50 mikem Exp $
 
 #include <RH_NRF24.h>
 

--- a/RH_NRF24.cpp
+++ b/RH_NRF24.cpp
@@ -1,7 +1,7 @@
 // NRF24.cpp
 //
 // Copyright (C) 2012 Mike McCauley
-// $Id: RH_NRF24.cpp,v 1.24 2017/06/20 05:21:17 mikem Exp $
+// $Id: RH_NRF24.cpp,v 1.25 2017/07/25 05:26:50 mikem Exp mikem $
 
 #include <RH_NRF24.h>
 

--- a/RH_NRF24.cpp
+++ b/RH_NRF24.cpp
@@ -1,7 +1,7 @@
 // NRF24.cpp
 //
 // Copyright (C) 2012 Mike McCauley
-// $Id: RH_NRF24.cpp,v 1.25 2017/07/25 05:26:50 mikem Exp $
+// $Id: RH_NRF24.cpp,v 1.26 2018/01/06 23:50:45 mikem Exp mikem $
 
 #include <RH_NRF24.h>
 
@@ -216,8 +216,13 @@ bool RH_NRF24::waitPacketSent()
     // end of transmission
     // We dont actually use auto-ack, so prob dont expect to see RH_NRF24_MAX_RT
     uint8_t status;
+    uint32_t start = millis();
     while (!((status = statusRead()) & (RH_NRF24_TX_DS | RH_NRF24_MAX_RT)))
+    {
+	if (((uint32_t)millis() - start) > 100) // Longer than any possible message
+	    break;  // Should never happen: TX never completed. Why?
 	YIELD;
+    }
 
     // Must clear RH_NRF24_MAX_RT if it is set, else no further comm
     if (status & RH_NRF24_MAX_RT)

--- a/RH_NRF24.cpp
+++ b/RH_NRF24.cpp
@@ -1,7 +1,7 @@
 // NRF24.cpp
 //
 // Copyright (C) 2012 Mike McCauley
-// $Id: RH_NRF24.cpp,v 1.26 2018/01/06 23:50:45 mikem Exp mikem $
+// $Id: RH_NRF24.cpp,v 1.26 2018/01/06 23:50:45 mikem Exp $
 
 #include <RH_NRF24.h>
 

--- a/RH_NRF24.cpp
+++ b/RH_NRF24.cpp
@@ -1,7 +1,7 @@
 // NRF24.cpp
 //
 // Copyright (C) 2012 Mike McCauley
-// $Id: RH_NRF24.cpp,v 1.23 2017/01/12 23:58:00 mikem Exp $
+// $Id: RH_NRF24.cpp,v 1.24 2017/06/20 05:21:17 mikem Exp mikem $
 
 #include <RH_NRF24.h>
 
@@ -42,6 +42,8 @@ bool RH_NRF24::init()
         if (spiReadRegister(RH_NRF24_REG_1D_FEATURE) != (RH_NRF24_EN_DPL | RH_NRF24_EN_DYN_ACK))
             return false;
     }
+
+    clearRxBuf();
 
     // Make sure we are powered down
     setModeIdle();

--- a/RH_NRF24.h
+++ b/RH_NRF24.h
@@ -632,6 +632,8 @@ private:
 
 /// @example nrf24_client.pde
 /// @example nrf24_server.pde
+/// @example nrf24_encrypted_client.pde
+/// @example nrf24_encrypted_server.pde
 /// @example nrf24_reliable_datagram_client.pde
 /// @example nrf24_reliable_datagram_server.pde
 /// @example RasPiRH.cpp

--- a/RH_NRF24.h
+++ b/RH_NRF24.h
@@ -1,7 +1,7 @@
 // RH_NRF24.h
 // Author: Mike McCauley
 // Copyright (C) 2012 Mike McCauley
-// $Id: RH_NRF24.h,v 1.20 2017/07/25 05:26:50 mikem Exp mikem $
+// $Id: RH_NRF24.h,v 1.20 2017/07/25 05:26:50 mikem Exp $
 //
 
 #ifndef RH_NRF24_h

--- a/RH_NRF24.h
+++ b/RH_NRF24.h
@@ -1,7 +1,7 @@
 // RH_NRF24.h
 // Author: Mike McCauley
 // Copyright (C) 2012 Mike McCauley
-// $Id: RH_NRF24.h,v 1.19 2016/07/07 00:02:53 mikem Exp $
+// $Id: RH_NRF24.h,v 1.20 2017/07/25 05:26:50 mikem Exp mikem $
 //
 
 #ifndef RH_NRF24_h
@@ -154,7 +154,7 @@
 
 /////////////////////////////////////////////////////////////////////
 /// \class RH_NRF24 RH_NRF24.h <RH_NRF24.h>
-/// \brief Send and receive addressed, reliable, acknowledged datagrams by nRF24L01 and compatible transceivers.
+/// \brief Send and receive unaddressed, unreliable datagrams by nRF24L01 and compatible transceivers.
 ///
 /// Supported transceivers include:
 /// - Nordic nRF24 based 2.4GHz radio modules, such as nRF24L01 http://www.nordicsemi.com/eng/Products/2.4GHz-RF/nRF24L01

--- a/RH_NRF51.h
+++ b/RH_NRF51.h
@@ -1,7 +1,7 @@
 // RH_NRF51.h
 // Author: Mike McCauley
 // Copyright (C) 2015 Mike McCauley
-// $Id: RH_NRF51.h,v 1.5 2017/07/25 05:26:50 mikem Exp mikem $
+// $Id: RH_NRF51.h,v 1.5 2017/07/25 05:26:50 mikem Exp $
 //
 
 #ifndef RH_NRF51_h

--- a/RH_NRF51.h
+++ b/RH_NRF51.h
@@ -1,7 +1,7 @@
 // RH_NRF51.h
 // Author: Mike McCauley
 // Copyright (C) 2015 Mike McCauley
-// $Id: RH_NRF51.h,v 1.4 2017/01/12 23:58:00 mikem Exp $
+// $Id: RH_NRF51.h,v 1.5 2017/07/25 05:26:50 mikem Exp mikem $
 //
 
 #ifndef RH_NRF51_h
@@ -45,7 +45,7 @@
 
 /////////////////////////////////////////////////////////////////////
 /// \class RH_NRF51 RH_NRF51.h <RH_NRF51.h>
-/// \brief Send and receive addressed datagrams by nRF51 and nRF52 compatible transceivers.
+/// \brief Send and receive unaddressed, unreliable datagrams by nRF51 and nRF52 compatible transceivers.
 ///
 /// Supported transceivers include:
 /// - Nordic nRF51 based 2.4GHz radio modules, such as nRF51822 

--- a/RH_NRF905.h
+++ b/RH_NRF905.h
@@ -1,7 +1,7 @@
 // RH_NRF905.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_NRF905.h,v 1.11 2017/07/25 05:26:50 mikem Exp mikem $
+// $Id: RH_NRF905.h,v 1.11 2017/07/25 05:26:50 mikem Exp $
 //
 
 #ifndef RH_NRF905_h

--- a/RH_NRF905.h
+++ b/RH_NRF905.h
@@ -1,7 +1,7 @@
 // RH_NRF905.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_NRF905.h,v 1.10 2017/01/12 23:58:00 mikem Exp $
+// $Id: RH_NRF905.h,v 1.11 2017/07/25 05:26:50 mikem Exp mikem $
 //
 
 #ifndef RH_NRF905_h
@@ -95,7 +95,7 @@
 
 /////////////////////////////////////////////////////////////////////
 /// \class RH_NRF905 RH_NRF905.h <RH_NRF905.h>
-/// \brief Send and receive addressed, reliable, acknowledged datagrams by nRF905 and compatible transceivers.
+/// \brief Send and receive unaddressed, unreliable datagrams by nRF905 and compatible transceivers.
 ///
 /// This base class provides basic functions for sending and receiving unaddressed, unreliable datagrams
 /// of arbitrary length to 28 octets per packet. Use one of the Manager classes to get addressing and 

--- a/RH_RF22.cpp
+++ b/RH_RF22.cpp
@@ -96,8 +96,8 @@ bool RH_RF22::init()
     if (   _deviceType != RH_RF22_DEVICE_TYPE_RX_TRX
         && _deviceType != RH_RF22_DEVICE_TYPE_TX)
     {
-	Serial.println("device type");
-	Serial.println(_deviceType);
+//	Serial.println("unknown device type");
+//	Serial.println(_deviceType);
 	return false;
     }
 

--- a/RH_RF22.cpp
+++ b/RH_RF22.cpp
@@ -1,7 +1,7 @@
 // RH_RF22.cpp
 //
 // Copyright (C) 2011 Mike McCauley
-// $Id: RH_RF22.cpp,v 1.28 2017/11/06 00:04:08 mikem Exp mikem $
+// $Id: RH_RF22.cpp,v 1.28 2017/11/06 00:04:08 mikem Exp $
 
 #include <RH_RF22.h>
 

--- a/RH_RF22.cpp
+++ b/RH_RF22.cpp
@@ -1,7 +1,7 @@
 // RH_RF22.cpp
 //
 // Copyright (C) 2011 Mike McCauley
-// $Id: RH_RF22.cpp,v 1.27 2017/01/12 23:58:00 mikem Exp $
+// $Id: RH_RF22.cpp,v 1.28 2017/11/06 00:04:08 mikem Exp mikem $
 
 #include <RH_RF22.h>
 

--- a/RH_RF22.cpp
+++ b/RH_RF22.cpp
@@ -84,6 +84,9 @@ bool RH_RF22::init()
     interruptNumber = _interruptPin;
 #endif
 
+    // Tell the low level SPI interface we will use SPI within this interrupt
+    spiUsingInterrupt(interruptNumber);
+
     // Software reset the device
     reset();
 
@@ -93,6 +96,8 @@ bool RH_RF22::init()
     if (   _deviceType != RH_RF22_DEVICE_TYPE_RX_TRX
         && _deviceType != RH_RF22_DEVICE_TYPE_TX)
     {
+	Serial.println("device type");
+	Serial.println(_deviceType);
 	return false;
     }
 

--- a/RH_RF22.h
+++ b/RH_RF22.h
@@ -1,7 +1,7 @@
 // RH_RF22.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2011 Mike McCauley
-// $Id: RH_RF22.h,v 1.32 2017/03/04 00:59:41 mikem Exp $
+// $Id: RH_RF22.h,v 1.33 2017/10/03 06:04:59 mikem Exp mikem $
 //
 
 #ifndef RH_RF22_h
@@ -606,6 +606,13 @@
 /// or the interrupt request to other than pin D2 (Caution, different processors have different constraints as to the 
 /// pins available for interrupts).
 ///
+/// Caution: some people have had problems with some batches of
+/// RFM23BP chips burning out their nIRQ outputs for unknown
+/// reasons when run at 5V. Some users assert that running RFM23BP with voltage
+/// dividers at 3.3V is to be preferred. We have not tested or verified
+/// either the cause or the supposed cure.
+//
+///
 /// If you have an Arduino Zero, you should note that you cannot use Pin 2 for the interrupt line 
 /// (Pin 2 is for the NMI only), instead you can use any other pin (we use Pin 3) and initialise RH_RF69 like this:
 /// \code
@@ -613,7 +620,29 @@
 /// RH_RF22 driver(10, 3);
 /// \endcode
 ///
-/// It is possible to have 2 radios connected to one Arduino, provided each radio has its own 
+/// If you have an ESP32 (we tested with the Geekworm EASY-KIT ESP32-B1 which has a ESP-WROOM-32 chip)
+/// \code
+///                 ESP32      RFM-22B
+///                 GND----------GND-\ (ground in)
+///                              SDN-/ (shutdown in)
+///                 3V3----------VCC   (3.3V in)
+/// interrupt   pin GPIO15-------NIRQ  (interrupt request out)
+///          SS pin GPIO13-------NSEL  (chip select in)
+///         SCK pin GPIO18-------SCK   (SPI clock in)
+///        MOSI pin GPIO23-------SDI   (SPI Data in)
+///        MISO pin GPIO19-------SDO   (SPI data out)
+///                           /--GPIO0 (GPIO0 out to control transmitter antenna TX_ANT)
+///                           \--TX_ANT (TX antenna control in) RFM22B only
+///                           /--GPIO1 (GPIO1 out to control receiver antenna RX_ANT)
+///                           \--RX_ANT (RX antenna control in) RFM22B only
+/// \endcode
+/// and initialise like this:
+/// \code
+/// RH_RF22 driver(13, 15);
+/// \endcode
+/// You can of course use other pins for NSEL and NIRQ if you prefer.
+///
+/// Note: It is possible to have 2 radios connected to one Arduino, provided each radio has its own 
 /// SS and interrupt line (SCK, SDI and SDO are common to both radios)
 ///
 /// Caution: on some Arduinos such as the Mega 2560, if you set the slave select pin to be other than the usual SS 

--- a/RH_RF22.h
+++ b/RH_RF22.h
@@ -1,7 +1,7 @@
 // RH_RF22.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2011 Mike McCauley
-// $Id: RH_RF22.h,v 1.33 2017/10/03 06:04:59 mikem Exp mikem $
+// $Id: RH_RF22.h,v 1.34 2017/11/06 00:04:08 mikem Exp mikem $
 //
 
 #ifndef RH_RF22_h
@@ -776,7 +776,7 @@
 ///
 /// - RH_RF22_RF23BP_TXPOW_28DBM
 /// - RH_RF22_RF23BP_TXPOW_29DBM
-/// - RH_RF22_RF23BP_TXPOW_38DBM
+/// - RH_RF22_RF23BP_TXPOW_30DBM
 ///
 /// CAUTION: the high power settings available on the RFM23BP require
 /// significant power supply current.  For example at +30dBm, the typical chip

--- a/RH_RF22.h
+++ b/RH_RF22.h
@@ -642,6 +642,29 @@
 /// \endcode
 /// You can of course use other pins for NSEL and NIRQ if you prefer.
 ///
+/// To connect an STM32 F4 Discovery board to RF22 using Arduino and Arduino_STM32
+/// connect the pins like this:
+/// \code
+///                 STM32      RFM-22B
+///                 GND----------GND-\ (ground in)
+///                              SDN-/ (shutdown in)
+///                 VDD----------VCC   (3.3V in)
+/// interrupt   pin PB1----------NIRQ  (interrupt request out)
+///          SS pin PB0----------NSEL  (chip select in)
+///         SCK pin PB3----------SCK   (SPI clock in)
+///        MOSI pin PB5----------SDI   (SPI Data in)
+///        MISO pin PB4----------SDO   (SPI data out)
+///                           /--GPIO0 (GPIO0 out to control transmitter antenna TX_ANT)
+///                           \--TX_ANT (TX antenna control in) RFM22B only
+///                           /--GPIO1 (GPIO1 out to control receiver antenna RX_ANT)
+///                           \--RX_ANT (RX antenna control in) RFM22B only
+/// \endcode
+/// and initialise like this:
+/// \code
+/// RH_RF22 driver(PB0, PB1);
+/// \endcode
+/// You can of use other pins for NSEL and NIRQ if you prefer.
+///
 /// Note: It is possible to have 2 radios connected to one Arduino, provided each radio has its own 
 /// SS and interrupt line (SCK, SDI and SDO are common to both radios)
 ///

--- a/RH_RF22.h
+++ b/RH_RF22.h
@@ -1,7 +1,7 @@
 // RH_RF22.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2011 Mike McCauley
-// $Id: RH_RF22.h,v 1.34 2017/11/06 00:04:08 mikem Exp mikem $
+// $Id: RH_RF22.h,v 1.34 2017/11/06 00:04:08 mikem Exp $
 //
 
 #ifndef RH_RF22_h

--- a/RH_RF24.cpp
+++ b/RH_RF24.cpp
@@ -54,6 +54,9 @@ bool RH_RF24::init()
     interruptNumber = _interruptPin;
 #endif
 
+    // Tell the low level SPI interface we will use SPI within this interrupt
+    spiUsingInterrupt(interruptNumber);
+
     // Initialise the radio
     power_on_reset();
     cmd_clear_all_interrupts();
@@ -345,11 +348,13 @@ bool RH_RF24::writeTxFifo(uint8_t *data, uint8_t len)
     ATOMIC_BLOCK_START;
     // First send the command
     digitalWrite(_slaveSelectPin, LOW);
+    _spi.beginTransaction();
     _spi.transfer(RH_RF24_CMD_TX_FIFO_WRITE);
     // Now write any write data
     while (len--)
 	_spi.transfer(*data++);
     digitalWrite(_slaveSelectPin, HIGH);
+    _spi.endTransaction();
     ATOMIC_BLOCK_END;
     return true;
 }

--- a/RH_RF24.cpp
+++ b/RH_RF24.cpp
@@ -1,7 +1,7 @@
 // RH_RF24.cpp
 //
 // Copyright (C) 2011 Mike McCauley
-// $Id: RH_RF24.cpp,v 1.21 2017/06/25 09:41:17 mikem Exp $
+// $Id: RH_RF24.cpp,v 1.22 2017/11/06 00:04:08 mikem Exp mikem $
 
 #include <RH_RF24.h>
 

--- a/RH_RF24.cpp
+++ b/RH_RF24.cpp
@@ -1,7 +1,7 @@
 // RH_RF24.cpp
 //
 // Copyright (C) 2011 Mike McCauley
-// $Id: RH_RF24.cpp,v 1.20 2017/03/08 09:30:47 mikem Exp mikem $
+// $Id: RH_RF24.cpp,v 1.20 2017/03/08 09:30:47 mikem Exp $
 
 #include <RH_RF24.h>
 

--- a/RH_RF24.cpp
+++ b/RH_RF24.cpp
@@ -1,7 +1,7 @@
 // RH_RF24.cpp
 //
 // Copyright (C) 2011 Mike McCauley
-// $Id: RH_RF24.cpp,v 1.22 2017/11/06 00:04:08 mikem Exp mikem $
+// $Id: RH_RF24.cpp,v 1.22 2017/11/06 00:04:08 mikem Exp $
 
 #include <RH_RF24.h>
 

--- a/RH_RF24.cpp
+++ b/RH_RF24.cpp
@@ -1,7 +1,7 @@
 // RH_RF24.cpp
 //
 // Copyright (C) 2011 Mike McCauley
-// $Id: RH_RF24.cpp,v 1.20 2017/03/08 09:30:47 mikem Exp $
+// $Id: RH_RF24.cpp,v 1.21 2017/06/25 09:41:17 mikem Exp $
 
 #include <RH_RF24.h>
 
@@ -411,6 +411,7 @@ uint8_t RH_RF24::maxMessageLength()
 void RH_RF24::setModemRegisters(const ModemConfig* config)
 {
   Serial.println("Programming Error: setModemRegisters is obsolete. Generate custom radio config file with WDS instead");
+  (void)config; // Prevent warnings
 }
 
 // Set one of the canned Modem configs
@@ -418,6 +419,7 @@ void RH_RF24::setModemRegisters(const ModemConfig* config)
 bool RH_RF24::setModemConfig(ModemConfigChoice index)
 {
   Serial.println("Programming Error: setModemRegisters is obsolete. Generate custom radio config file with WDS instead");
+  (void)index; // Prevent warnings
   return false;
 }
 
@@ -452,6 +454,7 @@ void RH_RF24::setSyncWords(const uint8_t* syncWords, uint8_t len)
 
 bool RH_RF24::setFrequency(float centre, float afcPullInRange)
 {
+  (void)afcPullInRange; // Not used
     // See Si446x Data Sheet section 5.3.1
     // Also the Si446x PLL Synthesizer / VCO_CNT Calculator Rev 0.4
     uint8_t outdiv;

--- a/RH_RF24.h
+++ b/RH_RF24.h
@@ -1,7 +1,7 @@
 // RH_RF24.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_RF24.h,v 1.17 2017/03/08 09:30:47 mikem Exp $
+// $Id: RH_RF24.h,v 1.18 2017/07/25 05:26:50 mikem Exp mikem $
 //
 // Supports RF24/RF26 and RFM24/RFM26 modules in FIFO mode
 // also Si4464/63/62/61/60-A1

--- a/RH_RF24.h
+++ b/RH_RF24.h
@@ -1,7 +1,7 @@
 // RH_RF24.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_RF24.h,v 1.18 2017/07/25 05:26:50 mikem Exp mikem $
+// $Id: RH_RF24.h,v 1.18 2017/07/25 05:26:50 mikem Exp $
 //
 // Supports RF24/RF26 and RFM24/RFM26 modules in FIFO mode
 // also Si4464/63/62/61/60-A1

--- a/RH_RF24.h
+++ b/RH_RF24.h
@@ -596,7 +596,7 @@
 ///
 /// The RH_RF24 module uses a radio configuration header file to configure the basic radio operation
 /// frequency and modulation scheme. The radio configuration header file must be generated with the
-/// Silicon Labs Wireless Development Suite (WDS) program and #included by RH_RF24.cpp
+/// Silicon Labs Wireless Development Suite (WDS) program and \#included by RH_RF24.cpp
 /// 
 /// The library will work out of the box and without further configuring with these parameters:
 /// - Si4464 or equvalent

--- a/RH_RF24.h
+++ b/RH_RF24.h
@@ -1,7 +1,7 @@
 // RH_RF24.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_RF24.h,v 1.17 2017/03/08 09:30:47 mikem Exp mikem $
+// $Id: RH_RF24.h,v 1.17 2017/03/08 09:30:47 mikem Exp $
 //
 // Supports RF24/RF26 and RFM24/RFM26 modules in FIFO mode
 // also Si4464/63/62/61/60-A1

--- a/RH_RF69.cpp
+++ b/RH_RF69.cpp
@@ -1,7 +1,7 @@
 // RH_RF69.cpp
 //
 // Copyright (C) 2011 Mike McCauley
-// $Id: RH_RF69.cpp,v 1.28 2017/06/20 05:21:17 mikem Exp mikem $
+// $Id: RH_RF69.cpp,v 1.29 2017/06/25 09:41:17 mikem Exp $
 
 #include <RH_RF69.h>
 
@@ -293,6 +293,7 @@ bool RH_RF69::setFrequency(float centre, float afcPullInRange)
     spiWrite(RH_RF69_REG_09_FRFLSB, frf & 0xff);
 
     // afcPullInRange is not used
+    (void)afcPullInRange;
     return true;
 }
 

--- a/RH_RF69.cpp
+++ b/RH_RF69.cpp
@@ -1,7 +1,7 @@
 // RH_RF69.cpp
 //
 // Copyright (C) 2011 Mike McCauley
-// $Id: RH_RF69.cpp,v 1.30 2017/11/06 00:04:08 mikem Exp mikem $
+// $Id: RH_RF69.cpp,v 1.30 2017/11/06 00:04:08 mikem Exp $
 
 #include <RH_RF69.h>
 

--- a/RH_RF69.cpp
+++ b/RH_RF69.cpp
@@ -1,7 +1,7 @@
 // RH_RF69.cpp
 //
 // Copyright (C) 2011 Mike McCauley
-// $Id: RH_RF69.cpp,v 1.29 2017/06/25 09:41:17 mikem Exp $
+// $Id: RH_RF69.cpp,v 1.30 2017/11/06 00:04:08 mikem Exp mikem $
 
 #include <RH_RF69.h>
 

--- a/RH_RF69.cpp
+++ b/RH_RF69.cpp
@@ -1,7 +1,7 @@
 // RH_RF69.cpp
 //
 // Copyright (C) 2011 Mike McCauley
-// $Id: RH_RF69.cpp,v 1.27 2017/01/12 23:58:00 mikem Exp $
+// $Id: RH_RF69.cpp,v 1.28 2017/06/20 05:21:17 mikem Exp mikem $
 
 #include <RH_RF69.h>
 

--- a/RH_RF69.cpp
+++ b/RH_RF69.cpp
@@ -110,6 +110,9 @@ bool RH_RF69::init()
     interruptNumber = _interruptPin;
 #endif
 
+    // Tell the low level SPI interface we will use SPI within this interrupt
+    spiUsingInterrupt(interruptNumber);
+
     // Get the device type and check it
     // This also tests whether we are really connected to a device
     // My test devices return 0x24
@@ -228,6 +231,7 @@ void RH_RF69::readFifo()
 {
     ATOMIC_BLOCK_START;
     digitalWrite(_slaveSelectPin, LOW);
+    _spi.beginTransaction();
     _spi.transfer(RH_RF69_REG_00_FIFO); // Send the start address with the write mask off
     uint8_t payloadlen = _spi.transfer(0); // First byte is payload len (counting the headers)
     if (payloadlen <= RH_RF69_MAX_ENCRYPTABLE_PAYLOAD_LEN &&
@@ -251,6 +255,7 @@ void RH_RF69::readFifo()
 	}
     }
     digitalWrite(_slaveSelectPin, HIGH);
+    _spi.endTransaction();
     ATOMIC_BLOCK_END;
     // Any junk remaining in the FIFO will be cleared next time we go to receive mode.
 }

--- a/RH_RF69.h
+++ b/RH_RF69.h
@@ -1,7 +1,7 @@
 // RH_RF69.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_RF69.h,v 1.35 2017/06/20 05:21:17 mikem Exp $
+// $Id: RH_RF69.h,v 1.36 2017/10/03 06:04:59 mikem Exp mikem $
 //
 ///
 
@@ -316,7 +316,7 @@
 ///   an Arduino compatible board, which include an on-board RF69 radio, external antenna, 
 ///   run on 2xAAA batteries and support low power operations. RF69 examples work without modification.
 ///   Use Arduino Board Manager to install the Talk2 code support as described in 
-///   https://bitbucket.org/talk2/whisper-node-avr
+///   https://bitbucket.org/talk2/whisper-node-avr. Upeload the code with an FTDI adapter set to 3.3V.
 /// - The excellent Adafruit Feather. These are excellent boards that are available with a variety of radios. 
 ///   We tested with the 
 ///   Feather 32u4 with RFM69HCW radio, with Arduino IDE 1.6.8 and the Adafruit AVR Boards board manager version 1.6.10.

--- a/RH_RF69.h
+++ b/RH_RF69.h
@@ -1,7 +1,7 @@
 // RH_RF69.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_RF69.h,v 1.35 2017/06/20 05:21:17 mikem Exp mikem $
+// $Id: RH_RF69.h,v 1.35 2017/06/20 05:21:17 mikem Exp $
 //
 ///
 

--- a/RH_RF69.h
+++ b/RH_RF69.h
@@ -1,7 +1,7 @@
 // RH_RF69.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_RF69.h,v 1.36 2017/10/03 06:04:59 mikem Exp mikem $
+// $Id: RH_RF69.h,v 1.36 2017/10/03 06:04:59 mikem Exp $
 //
 ///
 

--- a/RH_RF69.h
+++ b/RH_RF69.h
@@ -1,7 +1,7 @@
 // RH_RF69.h
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_RF69.h,v 1.34 2017/03/08 09:30:47 mikem Exp mikem $
+// $Id: RH_RF69.h,v 1.35 2017/06/20 05:21:17 mikem Exp mikem $
 //
 ///
 

--- a/RH_RF95.cpp
+++ b/RH_RF95.cpp
@@ -1,7 +1,7 @@
 // RH_RF95.cpp
 //
 // Copyright (C) 2011 Mike McCauley
-// $Id: RH_RF95.cpp,v 1.14 2017/03/04 00:59:41 mikem Exp $
+// $Id: RH_RF95.cpp,v 1.15 2017/06/20 05:21:17 mikem Exp mikem $
 
 #include <RH_RF95.h>
 
@@ -446,8 +446,13 @@ int RH_RF95::frequencyError()
     int32_t freqerror = 0;
 
     // Convert 2.5 bytes (5 nibbles, 20 bits) to 32 bit signed int
-    freqerror = spiRead(RH_RF95_REG_28_FEI_MSB) << 16;
-    freqerror |= spiRead(RH_RF95_REG_29_FEI_MID) << 8;
+    // Caution: some C compilers make errors with eg:
+    // freqerror = spiRead(RH_RF95_REG_28_FEI_MSB) << 16
+    // so we go more carefully.
+    freqerror = spiRead(RH_RF95_REG_28_FEI_MSB);
+    freqerror <<= 8;
+    freqerror |= spiRead(RH_RF95_REG_29_FEI_MID);
+    freqerror <<= 8;
     freqerror |= spiRead(RH_RF95_REG_2A_FEI_LSB);
     // Sign extension into top 3 nibbles
     if (freqerror & 0x80000)

--- a/RH_RF95.cpp
+++ b/RH_RF95.cpp
@@ -45,6 +45,9 @@ bool RH_RF95::init()
     interruptNumber = _interruptPin;
 #endif
 
+    // Tell the low level SPI interface we will use SPI within this interrupt
+    spiUsingInterrupt(interruptNumber);
+
     // No way to check the device type :-(
     
     // Set sleep mode, so we can also set LORA mode:
@@ -53,7 +56,7 @@ bool RH_RF95::init()
     // Check we are in sleep mode, with LORA set
     if (spiRead(RH_RF95_REG_01_OP_MODE) != (RH_RF95_MODE_SLEEP | RH_RF95_LONG_RANGE_MODE))
     {
-	Serial.println(spiRead(RH_RF95_REG_01_OP_MODE), HEX);
+//	Serial.println(spiRead(RH_RF95_REG_01_OP_MODE), HEX);
 	return false; // No device present?
     }
 

--- a/RH_RF95.cpp
+++ b/RH_RF95.cpp
@@ -170,7 +170,9 @@ void RH_RF95::handleInterrupt()
         _cad = irq_flags & RH_RF95_CAD_DETECTED;
         setModeIdle();
     }
-    
+    // Sigh: on some processors, for some unknown reason, doing this only once does not actually
+    // clear the radio's interrupt flag. So we do it twice. Why?
+    spiWrite(RH_RF95_REG_12_IRQ_FLAGS, 0xff); // Clear all IRQ flags
     spiWrite(RH_RF95_REG_12_IRQ_FLAGS, 0xff); // Clear all IRQ flags
 }
 

--- a/RH_RF95.cpp
+++ b/RH_RF95.cpp
@@ -1,7 +1,7 @@
 // RH_RF95.cpp
 //
 // Copyright (C) 2011 Mike McCauley
-// $Id: RH_RF95.cpp,v 1.17 2017/11/06 00:04:08 mikem Exp mikem $
+// $Id: RH_RF95.cpp,v 1.18 2018/01/06 23:50:45 mikem Exp mikem $
 
 #include <RH_RF95.h>
 
@@ -19,7 +19,7 @@ PROGMEM static const RH_RF95::ModemConfig MODEM_CONFIG_TABLE[] =
     { 0x72,   0x74,    0x04}, // Bw125Cr45Sf128 (the chip default), AGC enabled
     { 0x92,   0x74,    0x04}, // Bw500Cr45Sf128, AGC enabled
     { 0x48,   0x94,    0x04}, // Bw31_25Cr48Sf512, AGC enabled
-    { 0x78,   0xc4,    0x04}, // Bw125Cr48Sf4096, AGC enabled
+    { 0x78,   0xc4,    0x0c}, // Bw125Cr48Sf4096, AGC enabled
     
 };
 

--- a/RH_RF95.cpp
+++ b/RH_RF95.cpp
@@ -1,7 +1,7 @@
 // RH_RF95.cpp
 //
 // Copyright (C) 2011 Mike McCauley
-// $Id: RH_RF95.cpp,v 1.18 2018/01/06 23:50:45 mikem Exp mikem $
+// $Id: RH_RF95.cpp,v 1.18 2018/01/06 23:50:45 mikem Exp $
 
 #include <RH_RF95.h>
 

--- a/RH_RF95.cpp
+++ b/RH_RF95.cpp
@@ -1,7 +1,7 @@
 // RH_RF95.cpp
 //
 // Copyright (C) 2011 Mike McCauley
-// $Id: RH_RF95.cpp,v 1.16 2017/06/24 20:36:15 mikem Exp $
+// $Id: RH_RF95.cpp,v 1.17 2017/11/06 00:04:08 mikem Exp mikem $
 
 #include <RH_RF95.h>
 
@@ -16,10 +16,10 @@ uint8_t RH_RF95::_interruptCount = 0; // Index into _deviceForInterrupt for next
 PROGMEM static const RH_RF95::ModemConfig MODEM_CONFIG_TABLE[] =
 {
     //  1d,     1e,      26
-    { 0x72,   0x74,    0x00}, // Bw125Cr45Sf128 (the chip default)
-    { 0x92,   0x74,    0x00}, // Bw500Cr45Sf128
-    { 0x48,   0x94,    0x00}, // Bw31_25Cr48Sf512
-    { 0x78,   0xc4,    0x00}, // Bw125Cr48Sf4096
+    { 0x72,   0x74,    0x04}, // Bw125Cr45Sf128 (the chip default), AGC enabled
+    { 0x92,   0x74,    0x04}, // Bw500Cr45Sf128, AGC enabled
+    { 0x48,   0x94,    0x04}, // Bw31_25Cr48Sf512, AGC enabled
+    { 0x78,   0xc4,    0x04}, // Bw125Cr48Sf4096, AGC enabled
     
 };
 

--- a/RH_RF95.cpp
+++ b/RH_RF95.cpp
@@ -1,7 +1,7 @@
 // RH_RF95.cpp
 //
 // Copyright (C) 2011 Mike McCauley
-// $Id: RH_RF95.cpp,v 1.15 2017/06/20 05:21:17 mikem Exp mikem $
+// $Id: RH_RF95.cpp,v 1.16 2017/06/24 20:36:15 mikem Exp $
 
 #include <RH_RF95.h>
 

--- a/RH_RF95.cpp
+++ b/RH_RF95.cpp
@@ -125,7 +125,14 @@ void RH_RF95::handleInterrupt()
 {
     // Read the interrupt register
     uint8_t irq_flags = spiRead(RH_RF95_REG_12_IRQ_FLAGS);
-    if (_mode == RHModeRx && irq_flags & (RH_RF95_RX_TIMEOUT | RH_RF95_PAYLOAD_CRC_ERROR))
+    // Read the RegHopChannel register to check if CRC presence is signalled
+    // in the header. If not it might be a stray (noise) packet.*
+    uint8_t crc_present = spiRead(RH_RF95_REG_1C_HOP_CHANNEL);
+
+    if (_mode == RHModeRx
+	&& ((irq_flags & (RH_RF95_RX_TIMEOUT | RH_RF95_PAYLOAD_CRC_ERROR))
+	    | !(crc_present & RH_RF95_RX_PAYLOAD_CRC_IS_ON)))
+//    if (_mode == RHModeRx && irq_flags & (RH_RF95_RX_TIMEOUT | RH_RF95_PAYLOAD_CRC_ERROR))
     {
 	_rxBad++;
     }

--- a/RH_RF95.h
+++ b/RH_RF95.h
@@ -6,7 +6,7 @@
 //
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_RF95.h,v 1.17 2017/06/20 05:21:17 mikem Exp mikem $
+// $Id: RH_RF95.h,v 1.18 2017/06/24 20:36:15 mikem Exp $
 // 
 
 #ifndef RH_RF95_h
@@ -808,6 +808,8 @@ private:
 
 /// @example rf95_client.pde
 /// @example rf95_server.pde
+/// @example rf95_encrypted_client.pde
+/// @example rf95_encrypted_server.pde
 /// @example rf95_reliable_datagram_client.pde
 /// @example rf95_reliable_datagram_server.pde
 

--- a/RH_RF95.h
+++ b/RH_RF95.h
@@ -6,7 +6,7 @@
 //
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_RF95.h,v 1.20 2017/10/03 06:04:59 mikem Exp mikem $
+// $Id: RH_RF95.h,v 1.21 2017/11/06 00:04:08 mikem Exp mikem $
 // 
 
 #ifndef RH_RF95_h
@@ -262,6 +262,7 @@
 ///   an Arduino compatible board, which include an on-board RFM95/96 LoRa Radio (Semtech SX1276), external antenna, 
 ///   run on 2xAAA batteries and support low power operations. RF95 examples work without modification.
 ///   Use Arduino Board Manager to install the Talk2 code support. Upload the code with an FTDI adapter set to 5V.
+/// - heltec / TTGO ESP32 LoRa OLED https://www.aliexpress.com/item/Internet-Development-Board-SX1278-ESP32-WIFI-chip-0-96-inch-OLED-Bluetooth-WIFI-Lora-Kit-32/32824535649.html
 ///
 /// \par Overview
 ///

--- a/RH_RF95.h
+++ b/RH_RF95.h
@@ -6,7 +6,7 @@
 //
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_RF95.h,v 1.19 2017/07/25 05:26:50 mikem Exp mikem $
+// $Id: RH_RF95.h,v 1.20 2017/10/03 06:04:59 mikem Exp mikem $
 // 
 
 #ifndef RH_RF95_h
@@ -258,6 +258,10 @@
 ///   http://www.rocketscream.com/blog/product/mini-ultra-pro-with-radio/
 /// - Lora1276 module from NiceRF http://www.nicerf.com/product_view.aspx?id=99
 /// - Adafruit Feather M0 with RFM95 
+/// - The very fine Talk2 Whisper Node LoRa boards https://wisen.com.au/store/products/whisper-node-lora
+///   an Arduino compatible board, which include an on-board RFM95/96 LoRa Radio (Semtech SX1276), external antenna, 
+///   run on 2xAAA batteries and support low power operations. RF95 examples work without modification.
+///   Use Arduino Board Manager to install the Talk2 code support. Upload the code with an FTDI adapter set to 5V.
 ///
 /// \par Overview
 ///
@@ -412,6 +416,13 @@
 /// For Adafruit Feather M0 with RFM95, construct the driver like this:
 /// \code
 /// RH_RF95 rf95(8, 3);
+/// \endcode
+///
+/// If you have a talk2 Whisper Node LoRa board with on-board RF95 radio, 
+/// the example rf95_* sketches work without modification. Initialise the radio like
+/// with the default constructor:
+/// \code
+///  RH_RF95 driver;
 /// \endcode
 ///
 /// It is possible to have 2 or more radios connected to one Arduino, provided

--- a/RH_RF95.h
+++ b/RH_RF95.h
@@ -339,9 +339,9 @@
 /// this (tested).
 /// \code
 ///                 Teensy      inAir4 inAir9
-///                 GND----------GND   (ground in)
+///                 GND----------0V   (ground in)
 ///                 3V3----------3.3V  (3.3V in)
-/// interrupt 0 pin D2-----------D00   (interrupt request out)
+/// interrupt 0 pin D2-----------D0   (interrupt request out)
 ///          SS pin D10----------CS    (CS chip select in)
 ///         SCK pin D13----------CK    (SPI clock in)
 ///        MOSI pin D11----------SI    (SPI Data in)

--- a/RH_RF95.h
+++ b/RH_RF95.h
@@ -6,7 +6,7 @@
 //
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_RF95.h,v 1.18 2017/06/24 20:36:15 mikem Exp $
+// $Id: RH_RF95.h,v 1.19 2017/07/25 05:26:50 mikem Exp mikem $
 // 
 
 #ifndef RH_RF95_h

--- a/RH_RF95.h
+++ b/RH_RF95.h
@@ -6,7 +6,7 @@
 //
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_RF95.h,v 1.16 2017/03/04 00:59:41 mikem Exp $
+// $Id: RH_RF95.h,v 1.17 2017/06/20 05:21:17 mikem Exp mikem $
 // 
 
 #ifndef RH_RF95_h
@@ -622,6 +622,8 @@ public:
 
     /// Select one of the predefined modem configurations. If you need a modem configuration not provided 
     /// here, use setModemRegisters() with your own ModemConfig.
+    /// Caution: the slowest protocols may require a radio module with TCXO temperature controlled oscillator
+    /// for reliable operation.
     /// \param[in] index The configuration choice.
     /// \return true if index is a valid choice.
     bool        setModemConfig(ModemConfigChoice index);
@@ -728,11 +730,13 @@ public:
 
     /// Enable TCXO mode
     /// Call this immediately after init(), to force your radio to use an external 
-    /// frequency source, such as a Temperature Compensated Crystal Oscillator (TCXO).
+    /// frequency source, such as a Temperature Compensated Crystal Oscillator (TCXO), if available.
     /// See the comments in the main documentation about the sensitivity of this radio to
     /// clock frequency especially when using narrow bandwidths.
     /// Leaves the module in sleep mode.
     /// Caution, this function has not been tested by us.
+    /// Caution, the TCXO model radios are not low power when in sleep (consuming
+    /// about ~600 uA, reported by Phang Moh Lim.<br>
     void enableTCXO();
 
     /// Returns the last measured frequency error.

--- a/RH_RF95.h
+++ b/RH_RF95.h
@@ -6,7 +6,7 @@
 //
 // Author: Mike McCauley (mikem@airspayce.com)
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_RF95.h,v 1.21 2017/11/06 00:04:08 mikem Exp mikem $
+// $Id: RH_RF95.h,v 1.21 2017/11/06 00:04:08 mikem Exp $
 // 
 
 #ifndef RH_RF95_h

--- a/RH_Serial.cpp
+++ b/RH_Serial.cpp
@@ -5,6 +5,8 @@
 
 #include <RH_Serial.h>
 #if (RH_PLATFORM == RH_PLATFORM_STM32F2)
+#elif defined (ARDUINO_ARCH_STM32F4)
+ #include <libmaple/HardwareSerial.h>
 #else
  #include <HardwareSerial.h>
 #endif

--- a/RH_Serial.cpp
+++ b/RH_Serial.cpp
@@ -185,7 +185,6 @@ bool RH_Serial::recv(uint8_t* buf, uint8_t* len)
 {
     if (!available())
 	return false;
-
     if (buf && len)
     {
 	// Skip the 4 headers that are at the beginning of the rxBuf
@@ -200,6 +199,9 @@ bool RH_Serial::recv(uint8_t* buf, uint8_t* len)
 // Caution: this may block
 bool RH_Serial::send(const uint8_t* data, uint8_t len)
 {
+    if (len > RH_SERIAL_MAX_MESSAGE_LEN)
+	return false;
+
     if (!waitCAD()) 
 	return false;  // Check channel activity
 

--- a/RH_Serial.cpp
+++ b/RH_Serial.cpp
@@ -1,7 +1,7 @@
 // RH_Serial.cpp
 //
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_Serial.cpp,v 1.14 2017/10/03 06:04:59 mikem Exp mikem $
+// $Id: RH_Serial.cpp,v 1.14 2017/10/03 06:04:59 mikem Exp $
 
 #include <RH_Serial.h>
 #if (RH_PLATFORM == RH_PLATFORM_STM32F2)

--- a/RH_Serial.cpp
+++ b/RH_Serial.cpp
@@ -1,7 +1,7 @@
 // RH_Serial.cpp
 //
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_Serial.cpp,v 1.13 2017/01/12 23:58:00 mikem Exp $
+// $Id: RH_Serial.cpp,v 1.14 2017/10/03 06:04:59 mikem Exp mikem $
 
 #include <RH_Serial.h>
 #if (RH_PLATFORM == RH_PLATFORM_STM32F2)

--- a/RH_Serial.h
+++ b/RH_Serial.h
@@ -110,6 +110,10 @@ class HardwareSerial;
 /// - On Linux, names like /dev/ttyUSB0 (for a FTDO USB-serial converter)
 /// - On OSX, names like /dev/tty.usbserial-A501YSWL (for a FTDO USB-serial converter)
 ///
+/// On STM32 F4 Discovery with Arduino and Arduino_STM32, there are 4 serial ports. We had success with port 2
+/// (TX on pin PA2 and RX on pin PA3) and initialising the driver like this:
+/// RH_Serial driver(Serial2);
+///
 /// Note that it is necessary for you to select which Serial port your RF_Serial will use and pass it to the 
 /// contructor. On Linux you must pass an instance of HardwareSerial.
 ///

--- a/RH_Serial.h
+++ b/RH_Serial.h
@@ -1,7 +1,7 @@
 // RH_Serial.h
 //
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_Serial.h,v 1.11 2016/04/04 01:40:12 mikem Exp $
+// $Id: RH_Serial.h,v 1.12 2017/10/03 06:04:59 mikem Exp mikem $
 
 // Works with any serial port. Tested with Arduino Mega connected to Serial1
 // Also works with 3DR Radio V1.3 Telemetry kit (serial at 57600baud)

--- a/RH_Serial.h
+++ b/RH_Serial.h
@@ -254,5 +254,7 @@ protected:
 /// @example serial_reliable_datagram_client.pde
 /// @example serial_reliable_datagram_server.pde
 /// @example serial_gateway.pde
+/// @example serial_encrypted_reliable_datagram_client.pde
+/// @example serial_encrypted_reliable_datagram_server.pde
 
 #endif

--- a/RH_Serial.h
+++ b/RH_Serial.h
@@ -1,7 +1,7 @@
 // RH_Serial.h
 //
 // Copyright (C) 2014 Mike McCauley
-// $Id: RH_Serial.h,v 1.12 2017/10/03 06:04:59 mikem Exp mikem $
+// $Id: RH_Serial.h,v 1.12 2017/10/03 06:04:59 mikem Exp $
 
 // Works with any serial port. Tested with Arduino Mega connected to Serial1
 // Also works with 3DR Radio V1.3 Telemetry kit (serial at 57600baud)

--- a/RadioHead.h
+++ b/RadioHead.h
@@ -1,7 +1,7 @@
 // RadioHead.h
 // Author: Mike McCauley (mikem@airspayce.com) DO NOT CONTACT THE AUTHOR DIRECTLY
 // Copyright (C) 2014 Mike McCauley
-// $Id: RadioHead.h,v 1.66 2017/07/25 05:26:50 mikem Exp mikem $
+// $Id: RadioHead.h,v 1.67 2017/10/03 06:04:59 mikem Exp mikem $
 
 /// \mainpage RadioHead Packet Radio library for embedded microprocessors
 ///
@@ -10,7 +10,7 @@
 /// via a variety of common data radios and other transports on a range of embedded microprocessors.
 ///
 /// The version of the package that this documentation refers to can be downloaded 
-/// from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.79.zip
+/// from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.80.zip
 /// You can find the latest version of the documentation at http://www.airspayce.com/mikem/arduino/RadioHead
 ///
 /// You can also find online help and discussion at 
@@ -168,6 +168,8 @@
 ///    Examples serial_reliable_datagram_* and ask_* are shown to work. 
 ///    CAUTION: The GHz radio included in the ESP8266 is
 ///    not yet supported. 
+///  - Various Talk2 Whisper boards eg https://wisen.com.au/store/products/whisper-node-lora.
+///    Use Arduino Board Manager to install the Talk2 code support. 
 ///  - etc.
 ///
 /// - ChipKIT Core with Arduino IDE on any ChipKIT Core supported Digilent processor (tested on Uno32)
@@ -195,6 +197,10 @@
 /// - Adafruit Feather. These are excellent boards that are available with a variety of radios. We tested with the 
 ///   Feather 32u4 with RFM69HCW radio, with Arduino IDE 1.6.8 and the Adafruit AVR Boards board manager version 1.6.10. 
 ///   https://www.adafruit.com/products/3076
+///
+/// - ESP32 built using Arduino IDE 1.8.1 or later using the ESP32 toolchain installed per
+///   https://diyprojects.io/programming-esp32-board-arduino-ide-macos-windows-linux-arm-raspberrypi-orangepi/
+///   The internal 2.4GHz radio is not yet supported. Tested with RFM22 using SPI interfcace
 ///
 /// - Raspberry Pi
 ///   Uses BCM2835 library for GPIO http://www.airspayce.com/mikem/bcm2835/
@@ -299,6 +305,20 @@
 /// - Anarduino and HopeRF USA (http://www.hoperfusa.com and http://www.anarduino.com) who have a wide range
 ///   of HopeRF radios and Arduino integrated modules.
 /// - SparkFun https://www.sparkfun.com/ in USA who design and sell a wide range of Arduinos and radio modules.
+/// - Wisen http://wisen.com.au who design and sell a wide range of integrated radio/processor modules including the
+///   excellent Talk2 range.
+///
+/// \par Coding Style
+///
+/// RadioHead is designed so it can run on small processors with very
+/// limited resources and strict timing contraints.  As a result, we
+/// tend only to use the simplest and least demanding (in terms of memory and CPU) C++
+/// facilities. In particular we avoid as much as possible dynamic
+/// memory allocation, and the use of complex objects like C++
+/// strings, IO and buffers. We are happy with this, but we are aware
+/// that some people may think we are leaving useful tools on the
+/// table. You should not use this code as an example of how to do
+/// generalised C++ programming on well resourced processors.
 ///
 /// \par Donations
 ///
@@ -769,6 +789,14 @@
 ///              Changes to RH_CC110 driver to calculate RSSI in dBm, based on a patch from Jurie Pieterse.<br>
 ///              Added missing passthroughmethoids to RHEncryptedDriver, allowing it to be used with RHDatagram,
 ///              RHReliableDatagram etc. Tested with RH_Serial. Added examples 
+/// \version 1.80 2017-10-04
+///              Testing with the very fine Talk2 Whisper Node LoRa boards https://wisen.com.au/store/products/whisper-node-lora
+///              an Arduino compatible board, which include an on-board RFM95/96 LoRa Radio (Semtech SX1276), external antenna, 
+///              run on 2xAAA batteries and support low power operations. RF95 examples work without modification.
+///              Use Arduino Board Manager to install the Talk2 code support. Upload the code with an FTDI adapter set to 5V.<br>
+///              Added support for SPI transactions in development environments that support it with SPI_HAS_TRANSACTION.
+///              Tested on ESP32 with RFM-22 and Teensy 3.1 with RF69
+///              Added support for ESP32, tested with RFM-22 connected by SPI.<br>
 ///
 /// \author  Mike McCauley. DO NOT CONTACT THE AUTHOR DIRECTLY. USE THE MAILING LIST GIVEN ABOVE
 
@@ -1015,7 +1043,7 @@ these examples and explanations and extend them to suit your needs.
 
 // Official version numbers are maintained automatically by Makefile:
 #define RH_VERSION_MAJOR 1
-#define RH_VERSION_MINOR 79
+#define RH_VERSION_MINOR 80
 
 // Symbolic names for currently supported platform types
 #define RH_PLATFORM_ARDUINO          1
@@ -1097,6 +1125,7 @@ these examples and explanations and extend them to suit your needs.
  #include <SPI.h>
  #define RH_HAVE_HARDWARE_SPI
  #define RH_HAVE_SERIAL
+
 #elif (RH_PLATFORM == RH_PLATFORM_ESP32)   // ESP32 processor on Arduino IDE
  #include <Arduino.h>
  #include <SPI.h>

--- a/RadioHead.h
+++ b/RadioHead.h
@@ -1,7 +1,7 @@
 // RadioHead.h
 // Author: Mike McCauley (mikem@airspayce.com) DO NOT CONTACT THE AUTHOR DIRECTLY
 // Copyright (C) 2014 Mike McCauley
-// $Id: RadioHead.h,v 1.63 2017/06/20 05:21:17 mikem Exp mikem $
+// $Id: RadioHead.h,v 1.65 2017/06/25 09:41:17 mikem Exp $
 
 /// \mainpage RadioHead Packet Radio library for embedded microprocessors
 ///
@@ -10,7 +10,7 @@
 /// via a variety of common data radios and other transports on a range of embedded microprocessors.
 ///
 /// The version of the package that this documentation refers to can be downloaded 
-/// from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.77.zip
+/// from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.78.zip
 /// You can find the latest version of the documentation at http://www.airspayce.com/mikem/arduino/RadioHead
 ///
 /// You can also find online help and discussion at 
@@ -122,6 +122,10 @@
 /// For use with simulated sketches compiled and running on Linux.
 /// Works with tools/etherSimulator.pl to pass messages between simulated sketches, allowing
 /// testing of Manager classes on Linux and without need for real radios or other transport hardware.
+///
+/// - RHEncryptedDriver
+/// Adds encryption and decryption to any RadioHead transport driver, using any encrpytion cipher
+/// supported by ArduinoLibs Cryptogrphic Library http://rweather.github.io/arduinolibs/crypto.html
 ///
 /// Drivers can be used on their own to provide unaddressed, unreliable datagrams. 
 /// All drivers have the same identical API.
@@ -272,7 +276,7 @@
 /// cp /usr/local/projects/arduino/libraries/RadioHead/*.cpp .
 /// cp /usr/local/projects/arduino/libraries/RadioHead/examples/cc110/cc110_client/cc110_client.pde application.cpp
 /// \endcode
-/// - Edit application.cpp and comment out any #include <SPI.h> so it looks like:
+/// - Edit application.cpp and comment out any \#include <SPI.h> so it looks like:
 /// \code
 ///   // #include <SPI.h>
 /// \endcode
@@ -752,6 +756,12 @@
 ///              Increased the size of rssi variables to 16 bits to permit RSSI less than -128 as reported by RF95.
 /// \version 1.77 2017-06-25
 ///              Fixed a compilation error with lastRssi().<br>
+/// \version 1.78 2017-07-19
+///              Fixed a number of unused variable warnings from g++.<br>
+///              Added new module RHEncryptedDriver and examples, contributed by Philippe Rochat, which
+///              adds encryption and decryption to any RadioHead transport driver, using any encrpytion cipher
+///              supported by ArduinoLibs Cryptogrphic Library http://rweather.github.io/arduinolibs/crypto.html
+///              Includes several examples.<br>
 ///
 /// \author  Mike McCauley. DO NOT CONTACT THE AUTHOR DIRECTLY. USE THE MAILING LIST GIVEN ABOVE
 
@@ -760,7 +770,7 @@
 
 // Official version numbers are maintained automatically by Makefile:
 #define RH_VERSION_MAJOR 1
-#define RH_VERSION_MINOR 77
+#define RH_VERSION_MINOR 78
 
 // Symbolic names for currently supported platform types
 #define RH_PLATFORM_ARDUINO          1
@@ -1077,5 +1087,10 @@
 
 // This is the address that indicates a broadcast
 #define RH_BROADCAST_ADDRESS 0xff
+
+// Uncomment this is to enable Encryption module (see RHEncryptedDriver driver):
+// But ensure you have installed the Crypto directory from arduinolibs first:
+// http://rweather.github.io/arduinolibs/index.html
+//#define RH_ENABLE_ENCRYPTION_MODULE
 
 #endif

--- a/RadioHead.h
+++ b/RadioHead.h
@@ -1,7 +1,7 @@
 // RadioHead.h
 // Author: Mike McCauley (mikem@airspayce.com) DO NOT CONTACT THE AUTHOR DIRECTLY
 // Copyright (C) 2014 Mike McCauley
-// $Id: RadioHead.h,v 1.67 2017/10/03 06:04:59 mikem Exp mikem $
+// $Id: RadioHead.h,v 1.68 2017/11/06 00:04:08 mikem Exp mikem $
 
 /// \mainpage RadioHead Packet Radio library for embedded microprocessors
 ///
@@ -10,7 +10,7 @@
 /// via a variety of common data radios and other transports on a range of embedded microprocessors.
 ///
 /// The version of the package that this documentation refers to can be downloaded 
-/// from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.80.zip
+/// from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.81.zip
 /// You can find the latest version of the documentation at http://www.airspayce.com/mikem/arduino/RadioHead
 ///
 /// You can also find online help and discussion at 
@@ -193,6 +193,9 @@
 ///
 /// - nRF51 compatible Arm chips such as nRF51822 with Arduino 1.6.4 and later using the procedures
 ///   in http://redbearlab.com/getting-started-nrf51822/
+///
+/// - nRF52 compatible Arm chips such as as Adafruit BLE Feather board
+/// https://www.adafruit.com/product/3406
 ///
 /// - Adafruit Feather. These are excellent boards that are available with a variety of radios. We tested with the 
 ///   Feather 32u4 with RFM69HCW radio, with Arduino IDE 1.6.8 and the Adafruit AVR Boards board manager version 1.6.10. 
@@ -798,7 +801,17 @@
 ///              Tested on ESP32 with RFM-22 and Teensy 3.1 with RF69
 ///              Added support for ESP32, tested with RFM-22 connected by SPI.<br>
 ///
-/// \author  Mike McCauley. DO NOT CONTACT THE AUTHOR DIRECTLY. USE THE MAILING LIST GIVEN ABOVE
+///\version 1.81 2017-11-15
+///              RH_CC110, moved setPaTable() from protected to public.<br>
+///              RH_RF95 modem config Bw125Cr48Sf4096 altered to enable slow daat rate in register 26
+///              as suggested by Dieter Kneffel.
+///              Added support for nRF52 compatible Arm chips such as as Adafruit BLE Feather board
+///              https://www.adafruit.com/product/3406, with a patch from Mike Bell.<br>
+///              Fixed a problem where rev 1.80 broke Adafruit M0 LoRa support by declaring 
+///              bitOrder variable always as a unsigned char. Reported by Guilherme Jardim.<br>
+///              In RH_RF95, all modes now have AGC enabled, as suggested by Dieter Kneffel.<br>
+///
+/// \author  Mike McCauley. DO NOT CONTACT THE AUTHOR DIRECTLY. USE THE GOOGLE LIST GIVEN ABOVE
 
 /*! \page packingdata 
 \par Passing Sensor Data Between RadioHead nodes
@@ -1043,7 +1056,7 @@ these examples and explanations and extend them to suit your needs.
 
 // Official version numbers are maintained automatically by Makefile:
 #define RH_VERSION_MAJOR 1
-#define RH_VERSION_MINOR 80
+#define RH_VERSION_MINOR 81
 
 // Symbolic names for currently supported platform types
 #define RH_PLATFORM_ARDUINO          1
@@ -1209,15 +1222,13 @@ these examples and explanations and extend them to suit your needs.
 #elif (RH_PLATFORM == RH_PLATFORM_NRF51)
  #define RH_HAVE_SERIAL
  #define PROGMEM
- #define RH_HAVE_HARDWARE_SPI
- #include <SPI.h> 
  #include <Arduino.h>
 
 #elif (RH_PLATFORM == RH_PLATFORM_NRF52)
+ #include <SPI.h>
+ #define RH_HAVE_HARDWARE_SPI
  #define RH_HAVE_SERIAL
  #define PROGMEM
- #define RH_HAVE_HARDWARE_SPI
- #include <SPI.h> 
  #include <Arduino.h>
 
 #elif (RH_PLATFORM == RH_PLATFORM_UNIX) 

--- a/RadioHead.h
+++ b/RadioHead.h
@@ -1,822 +1,844 @@
 // RadioHead.h
 // Author: Mike McCauley (mikem@airspayce.com) DO NOT CONTACT THE AUTHOR DIRECTLY
 // Copyright (C) 2014 Mike McCauley
-// $Id: RadioHead.h,v 1.69 2018/01/06 23:50:45 mikem Exp mikem $
+// $Id: RadioHead.h,v 1.70 2018/02/11 23:57:18 mikem Exp mikem $
 
-/// \mainpage RadioHead Packet Radio library for embedded microprocessors
-///
-/// This is the RadioHead Packet Radio library for embedded microprocessors.
-/// It provides a complete object-oriented library for sending and receiving packetized messages
-/// via a variety of common data radios and other transports on a range of embedded microprocessors.
-///
-/// The version of the package that this documentation refers to can be downloaded 
-/// from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.82.zip
-/// You can find the latest version of the documentation at http://www.airspayce.com/mikem/arduino/RadioHead
-///
-/// You can also find online help and discussion at 
-/// http://groups.google.com/group/radiohead-arduino
-/// Please use that group for all questions and discussions on this topic. 
-/// Do not contact the author directly, unless it is to discuss commercial licensing.
-/// Before asking a question or reporting a bug, please read 
-/// - http://en.wikipedia.org/wiki/Wikipedia:Reference_desk/How_to_ask_a_software_question
-/// - http://www.catb.org/esr/faqs/smart-questions.html
-/// - http://www.chiark.greenend.org.uk/~shgtatham/bugs.html
-///
-/// \par Overview
-///
-/// RadioHead consists of 2 main sets of classes: Drivers and Managers.
-///
-/// - Drivers provide low level access to a range of different packet radios and other packetized message transports.
-/// - Managers provide high level message sending and receiving facilities for a range of different requirements.
-///
-/// Every RadioHead program will have an instance of a Driver to provide access to the data radio or transport, 
-/// and a Manager that uses that driver to send and receive messages for the application. The programmer is required
-/// to instantiate a Driver and a Manager, and to initialise the Manager. Thereafter the facilities of the Manager
-/// can be used to send and receive messages.
-///
-/// It is also possible to use a Driver on its own, without a Manager, although this only allows unaddressed, 
-/// unreliable transport via the Driver's facilities.
-///
-/// In some specialised use cases, it is possible to instantiate more than one Driver and more than one Manager.
-///
-/// A range of different common embedded microprocessor platforms are supported, allowing your project to run
-/// on your choice of processor.
-///
-/// Example programs are included to show the main modes of use.
-///
-/// \par Drivers
-///
-/// The following Drivers are provided:
-///
-/// - RH_RF22
-/// Works with Hope-RF
-/// RF22B and RF23B based transceivers, and compatible chips and modules, 
-/// including the RFM22B transceiver module such as 
-/// this bare module: http://www.sparkfun.com/products/10153
-/// and this shield: http://www.sparkfun.com/products/11018 
-/// and this board: http://www.anarduino.com/miniwireless
-/// and RF23BP modules such as: http://www.anarduino.com/details.jsp?pid=130
-/// Supports GFSK, FSK and OOK. Access to other chip 
-/// features such as on-chip temperature measurement, analog-digital 
-/// converter, transmitter power control etc is also provided.
-///
-/// - RH_RF24
-/// Works with Silicon Labs Si4460/4461/4463/4464 family of transceivers chip, and the equivalent
-/// HopeRF RF24/26/27 family of chips and the HopeRF RFM24W/26W/27W modules.
-/// Supports GFSK, FSK and OOK. Access to other chip 
-/// features such as on-chip temperature measurement, analog-digital 
-/// converter, transmitter power control etc is also provided.
-///
-/// - RH_RF69 
-/// Works with Hope-RF
-/// RF69B based radio modules, such as the RFM69 module, (as used on the excellent Moteino and Moteino-USB 
-/// boards from LowPowerLab http://lowpowerlab.com/moteino/ )
-/// and compatible chips and modules such as RFM69W, RFM69HW, RFM69CW, RFM69HCW (Semtech SX1231, SX1231H).
-/// Also works with Anarduino MiniWireless -CW and -HW boards http://www.anarduino.com/miniwireless/ including
-/// the marvellous high powered MinWireless-HW (with 20dBm output for excellent range).
-/// Supports GFSK, FSK.
-///
-/// - RH_NRF24
-/// Works with Nordic nRF24 based 2.4GHz radio modules, such as nRF24L01 and others.
-/// Also works with Hope-RF RFM73 
-/// and compatible devices (such as BK2423). nRF24L01 and RFM73 can interoperate
-/// with each other.
-///
-/// - RH_NRF905
-/// Works with Nordic nRF905 based 433/868/915 MHz radio modules.
-///
-/// - RH_NRF51
-/// Works with Nordic nRF51 compatible 2.4 GHz SoC/devices such as the nRF51822.
-/// Also works with Sparkfun nRF52832 breakout board, with Arduino 1.6.13 and
-/// Sparkfun nRF52 boards manager 0.2.3
-///
-/// - RH_RF95
-/// Works with Semtech SX1276/77/78/79, Modtronix inAir4 and inAir9,
-/// and HopeRF RFM95/96/97/98 and other similar LoRa capable radios.
-/// Supports Long Range (LoRa) with spread spectrum frequency hopping, large payloads etc.
-/// FSK/GFSK/OOK modes are not (yet) supported.
-///
-/// - RH_MRF89
-/// Works with Microchip MRF89XA and compatible transceivers.
-/// and modules such as MRF89XAM9A.
-///
-/// - RH_CC110
-/// Works with Texas Instruments CC110L transceivers and compatible modules such as Anaren AIR BoosterPack 430BOOST-CC110L
-///
-/// - RH_E32
-/// Works with EBYTE E32-TTL-1W serial radio transceivers (and possibly other transceivers in the same family)
-///
-/// - RH_ASK
-/// Works with a range of inexpensive ASK (amplitude shift keying) RF transceivers such as RX-B1 
-/// (also known as ST-RX04-ASK) receiver; TX-C1 transmitter and DR3100 transceiver; FS1000A/XY-MK-5V transceiver;
-/// HopeRF RFM83C / RFM85. Supports ASK (OOK).
-///
-/// - RH_Serial
-/// Works with RS232, RS422, RS485, RS488 and other point-to-point and multidropped serial connections, 
-/// or with TTL serial UARTs such as those on Arduino and many other processors,
-/// or with data radios with a 
-/// serial port interface. RH_Serial provides packetization and error detection over any hardware or 
-/// virtual serial connection. Also builds and runs on Linux and OSX.
-///
-/// - RH_TCP
-/// For use with simulated sketches compiled and running on Linux.
-/// Works with tools/etherSimulator.pl to pass messages between simulated sketches, allowing
-/// testing of Manager classes on Linux and without need for real radios or other transport hardware.
-///
-/// - RHEncryptedDriver
-/// Adds encryption and decryption to any RadioHead transport driver, using any encrpytion cipher
-/// supported by ArduinoLibs Cryptogrphic Library http://rweather.github.io/arduinolibs/crypto.html
-///
-/// Drivers can be used on their own to provide unaddressed, unreliable datagrams. 
-/// All drivers have the same identical API.
-/// Or you can use any Driver with any of the Managers described below.
-///
-/// We welcome contributions of well tested and well documented code to support other transports.
-///
-/// \par Managers
-///
-/// The following Mangers are provided:
-///
-/// - RHDatagram
-/// Addressed, unreliable variable length messages, with optional broadcast facilities.
-///
-/// - RHReliableDatagram
-/// Addressed, reliable, retransmitted, acknowledged variable length messages.
-///
-/// - RHRouter
-/// Multi-hop delivery from source node to destination node via 0 or more intermediate nodes, with manual routing.
-///
-/// - RHMesh
-/// Multi-hop delivery with automatic route discovery and rediscovery.
-///
-/// Any Manager may be used with any Driver.
-///
-/// \par Platforms
-/// 
-/// A range of platforms is supported:
-///
-/// - Arduino and the Arduino IDE (version 1.0 to 1.8.1 and later)
-/// Including Diecimila, Uno, Mega, Leonardo, Yun, Due, Zero etc. http://arduino.cc/, Also similar boards such as 
-///  - Moteino http://lowpowerlab.com/moteino/ 
-///  - Anarduino Mini http://www.anarduino.com/mini/ 
-///  - RedBearLab Blend V1.0 http://redbearlab.com/blend/ (with Arduino 1.0.5 and RedBearLab Blend Add-On version 20140701) 
-///  -  MoteinoMEGA https://lowpowerlab.com/shop/moteinomega 
-///     (with Arduino 1.0.5 and the MoteinoMEGA Arduino Core 
-///     https://github.com/LowPowerLab/Moteino/tree/master/MEGA/Core)
-///  - ESP8266 on Arduino IDE and Boards Manager per https://github.com/esp8266/Arduino 
-///    Tested using Arduino 1.6.8 with esp8266 by ESP8266 Community version 2.1.0
-///    Examples serial_reliable_datagram_* and ask_* are shown to work. 
-///    CAUTION: The GHz radio included in the ESP8266 is
-///    not yet supported. 
-///  - Various Talk2 Whisper boards eg https://wisen.com.au/store/products/whisper-node-lora.
-///    Use Arduino Board Manager to install the Talk2 code support. 
-///  - etc.
-///
-/// - ChipKIT Core with Arduino IDE on any ChipKIT Core supported Digilent processor (tested on Uno32)
-/// http://chipkit.net/wiki/index.php?title=ChipKIT_core
-///
-/// - Maple and Flymaple boards with libmaple and the Maple-IDE development environment
-/// http://leaflabs.com/devices/maple/ and http://www.open-drone.org/flymaple
-///
-/// - Teensy including Teensy 3.1 and earlier built using Arduino IDE 1.0.5 to 1.6.4 and later with 
-///   teensyduino addon 1.18 to 1.23 and later.
-///   http://www.pjrc.com/teensy
-///
-/// - Particle Photon https://store.particle.io/collections/photon and ARM3 based CPU with built-in 
-///   Wi-Fi transceiver and extensive IoT software suport. RadioHead does not support the built-in transceiver
-///   but can be used to control other SPI based radios, Serial ports etc.
-///   See below for details on how to build RadioHead for Photon
-///
-/// - ATtiny built using Arduino IDE 1.0.5 with the arduino-tiny support from https://code.google.com/p/arduino-tiny/
-///   and Digispark built with Arduino 1.6.5.
-///   (Caution: these are very small processors and not all RadioHead features may be available, depending on memory requirements)
-///
-/// - nRF51 compatible Arm chips such as nRF51822 with Arduino 1.6.4 and later using the procedures
-///   in http://redbearlab.com/getting-started-nrf51822/
-///
-/// - nRF52 compatible Arm chips such as as Adafruit BLE Feather board
-/// https://www.adafruit.com/product/3406
-///
-/// - Adafruit Feather. These are excellent boards that are available with a variety of radios. We tested with the 
-///   Feather 32u4 with RFM69HCW radio, with Arduino IDE 1.6.8 and the Adafruit AVR Boards board manager version 1.6.10. 
-///   https://www.adafruit.com/products/3076
-///
-/// - ESP32 built using Arduino IDE 1.8.1 or later using the ESP32 toolchain installed per
-///   https://diyprojects.io/programming-esp32-board-arduino-ide-macos-windows-linux-arm-raspberrypi-orangepi/
-///   The internal 2.4GHz radio is not yet supported. Tested with RFM22 using SPI interfcace
-///
-/// - Raspberry Pi
-///   Uses BCM2835 library for GPIO http://www.airspayce.com/mikem/bcm2835/
-///   Currently works only with RH_NRF24 driver or other drivers that do not require interrupt support.
-///   Contributed by Mike Poublon.
-///
-/// - Linux and OSX
-///   Using the RHutil/HardwareSerial class, the RH_Serial driver and any manager will
-///   build and run on Linux and OSX. These can be used to build programs that talk securely and reliably to
-///   Arduino and other processors or to other Linux or OSX hosts on a reliable, error detected datagram
-///   protocol over a serial line.
-///
-/// Other platforms are partially supported, such as Generic AVR 8 bit processors, MSP430. 
-/// We welcome contributions that will expand the range of supported platforms. 
-///
-/// RadioHead is available (through the efforts of others) 
-/// for PlatformIO. PlatformIO is a cross-platform code builder and the missing library manager.
-/// http://platformio.org/#!/lib/show/124/RadioHead
-///
-/// \par History
-///
-/// RadioHead was created in April 2014, substantially based on code from some of our other earlier Radio libraries:
-///
-/// - RHMesh, RHRouter, RHReliableDatagram and RHDatagram are derived from the RF22 library version 1.39.
-/// - RH_RF22 is derived from the RF22 library version 1.39.
-/// - RH_RF69 is derived from the RF69 library version 1.2.
-/// - RH_ASK is based on the VirtualWire library version 1.26, after significant conversion to C++.
-/// - RH_Serial was new.
-/// - RH_NRF24 is based on the NRF24 library version 1.12, with some significant changes.
-///
-/// During this combination and redevelopment, we have tried to retain all the processor dependencies and support from
-/// the libraries that were contributed by other people. However not all platforms can be tested by us, so if you
-/// find that support from some platform has not been successfully migrated, please feel free to fix it and send us a 
-/// patch.
-///
-/// Users of RHMesh, RHRouter, RHReliableDatagram and RHDatagram in the previous RF22 library will find that their
-/// existing code will run mostly without modification. See the RH_RF22 documentation for more details.
-///
-/// \par Installation
-///
-/// Install in the usual way: unzip the distribution zip file to the libraries
-/// sub-folder of your sketchbook. 
-/// The example sketches will be visible in in your Arduino, mpide, maple-ide or whatever.
-/// http://arduino.cc/en/Guide/Libraries
-///
-/// \par Building for Particle Photon
-///
-/// The Photon is not supported by the Arduino IDE, so it takes a little effort to set up a build environment.
-/// Heres what we did to enable building of RadioHead example sketches on Linux, 
-/// but there are other ways to skin this cat.
-/// Basic reference for getting stated is: http://particle-firmware.readthedocs.org/en/develop/build/
-/// - Download the ARM gcc cross compiler binaries and unpack it in a suitable place:
-/// \code
-/// cd /tmp
-/// wget https://launchpad.net/gcc-arm-embedded/5.0/5-2015-q4-major/+download/gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2
-/// tar xvf gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2
-/// \endcode
-/// - If dfu-util and friends not installed on your platform, download dfu-util and friends to somewhere in your path
-/// \code
-/// cd ~/bin
-/// wget http://dfu-util.sourceforge.net/releases/dfu-util-0.8-binaries/linux-i386/dfu-util
-/// wget http://dfu-util.sourceforge.net/releases/dfu-util-0.8-binaries/linux-i386/dfu-suffix
-/// wget http://dfu-util.sourceforge.net/releases/dfu-util-0.8-binaries/linux-i386/dfu-prefix
-/// \endcode
-/// - Download the Particle firmware (contains headers and libraries require to compile Photon sketches) 
-///   to a suitable place:
-/// \code
-/// cd /tmp
-/// wget https://github.com/spark/firmware/archive/develop.zip
-/// unzip develop.zip
-/// \endcode
-/// - Make a working area containing the RadioHead library source code and your RadioHead sketch. You must
-///   rename the sketch from .pde or .ino to application.cpp
-/// \code
-/// cd /tmp
-/// mkdir RadioHead
-/// cd RadioHead
-/// cp /usr/local/projects/arduino/libraries/RadioHead/*.h .
-/// cp /usr/local/projects/arduino/libraries/RadioHead/*.cpp .
-/// cp /usr/local/projects/arduino/libraries/RadioHead/examples/cc110/cc110_client/cc110_client.pde application.cpp
-/// \endcode
-/// - Edit application.cpp and comment out any \#include <SPI.h> so it looks like:
-/// \code
-///   // #include <SPI.h>
-/// \endcode
-/// - Connect your Photon by USB. Put it in DFU mode as descibed in Photon documentation. Light should be flashing yellow
-/// - Compile the RadioHead sketch and install it as the user program (this does not update the rest of the
-///   Photon firmware, just the user part:
-/// \code
-/// cd /tmp/firmware-develop/main
-/// PATH=$PATH:/tmp/gcc-arm-none-eabi-5_2-2015q4/bin make APPDIR=/tmp/RadioHead all PLATFORM=photon program-dfu
-/// \endcode
-/// - You should see RadioHead compile without errors and download the finished sketch into the Photon.
-///
-/// \par Compatible Hardware Suppliers
-///
-/// We have had good experiences with the following suppliers of RadioHead compatible hardware:
-///
-/// - LittleBird http://littlebirdelectronics.com.au in Australia for all manner of Arduinos and radios.
-/// - LowPowerLab http://lowpowerlab.com/moteino in USA for the excellent Moteino and Moteino-USB 
-///   boards which include Hope-RF RF69B radios on-board.
-/// - Anarduino and HopeRF USA (http://www.hoperfusa.com and http://www.anarduino.com) who have a wide range
-///   of HopeRF radios and Arduino integrated modules.
-/// - SparkFun https://www.sparkfun.com/ in USA who design and sell a wide range of Arduinos and radio modules.
-/// - Wisen http://wisen.com.au who design and sell a wide range of integrated radio/processor modules including the
-///   excellent Talk2 range.
-///
-/// \par Coding Style
-///
-/// RadioHead is designed so it can run on small processors with very
-/// limited resources and strict timing contraints.  As a result, we
-/// tend only to use the simplest and least demanding (in terms of memory and CPU) C++
-/// facilities. In particular we avoid as much as possible dynamic
-/// memory allocation, and the use of complex objects like C++
-/// strings, IO and buffers. We are happy with this, but we are aware
-/// that some people may think we are leaving useful tools on the
-/// table. You should not use this code as an example of how to do
-/// generalised C++ programming on well resourced processors.
-///
-/// \par Donations
-///
-/// This library is offered under a free GPL license for those who want to use it that way. 
-/// We try hard to keep it up to date, fix bugs
-/// and to provide free support. If this library has helped you save time or money, please consider donating at
-/// http://www.airspayce.com or here:
-///
-/// \htmlonly <form action="https://www.paypal.com/cgi-bin/webscr" method="post"><input type="hidden" name="cmd" value="_donations" /> <input type="hidden" name="business" value="mikem@airspayce.com" /> <input type="hidden" name="lc" value="AU" /> <input type="hidden" name="item_name" value="Airspayce" /> <input type="hidden" name="item_number" value="RadioHead" /> <input type="hidden" name="currency_code" value="USD" /> <input type="hidden" name="bn" value="PP-DonationsBF:btn_donateCC_LG.gif:NonHosted" /> <input type="image" alt="PayPal — The safer, easier way to pay online." name="submit" src="https://www.paypalobjects.com/en_AU/i/btn/btn_donateCC_LG.gif" /> <img alt="" src="https://www.paypalobjects.com/en_AU/i/scr/pixel.gif" width="1" height="1" border="0" /></form> \endhtmlonly
-/// 
-/// \subpage packingdata "Passing Sensor Data Between RadioHead nodes"
-///
-/// \par Trademarks
-///
-/// RadioHead is a trademark of AirSpayce Pty Ltd. The RadioHead mark was first used on April 12 2014 for
-/// international trade, and is used only in relation to data communications hardware and software and related services.
-/// It is not to be confused with any other similar marks covering other goods and services.
-///
-/// \par Copyright
-///
-/// This software is Copyright (C) 2011-2016 Mike McCauley. Use is subject to license
-/// conditions. The main licensing options available are GPL V2 or Commercial:
-/// 
-/// \par Open Source Licensing GPL V2
-///
-/// This is the appropriate option if you want to share the source code of your
-/// application with everyone you distribute it to, and you also want to give them
-/// the right to share who uses it. If you wish to use this software under Open
-/// Source Licensing, you must contribute all your source code to the open source
-/// community in accordance with the GPL Version 2 when your application is
-/// distributed. See https://www.gnu.org/licenses/gpl-2.0.html
-/// 
-/// \par Commercial Licensing
-///
-/// This is the appropriate option if you are creating proprietary applications
-/// and you are not prepared to distribute and share the source code of your
-/// application. Purchase commercial licenses at http://airspayce.binpress.com
-///
-/// \par Revision History
-/// \version 1.1 2014-04-14<br>
-///              Initial public release
-/// \version 1.2 2014-04-23<br>
-///              Fixed various typos. <br>
-///              Added links to compatible Anarduino products.<br>
-///              Added RHNRFSPIDriver, RH_NRF24 classes to support Nordic NRF24 based radios.
-/// \version 1.3 2014-04-28<br>
-///              Various documentation fixups.<br>
-///              RHDatagram::setThisAddress() did not set the local copy of thisAddress. Reported by Steve Childress.<br>
-///              Fixed a problem on Teensy with RF22 and RF69, where the interrupt pin needs to be set for input, <br>
-///              else pin interrupt doesn't work properly. Reported by Steve Childress and patched by 
-///              Adrien van den Bossche. Thanks.<br>
-///              Fixed a problem that prevented RF22 honouring setPromiscuous(true). Reported by Steve Childress.<br>
-///              Updated documentation to clarify some issues to do with maximum message lengths 
-///              reported by Steve Childress.<br>
-///              Added support for yield() on systems that support it (currently Arduino 1.5.5 and later)
-///              so that spin-loops can suport multitasking. Suggested by Steve Childress.<br>
-///              Added RH_RF22::setGpioReversed() so the reversal it can be configured at run-time after
-///              radio initialisation. It must now be called _after_ init(). Suggested by Steve Childress.<br>
-/// \version 1.4 2014-04-29<br>
-///              Fixed further problems with Teensy compatibility for RH_RF22. Tested on Teensy 3.1.
-///              The example/rf22_* examples now run out of the box with the wiring connections as documented for Teensy
-///              in RH_RF22.<br>
-///              Added YIELDs to spin-loops in RHRouter, RHMesh and RHReliableDatagram, RH_NRF24.<br>
-///              Tested RH_Serial examples with Teensy 3.1: they now run out of the box.<br>
-///              Tested RH_ASK examples with Teensy 3.1: they now run out of the box.<br>
-///              Reduced default SPI speed for NRF24 from 8MHz to 1MHz on Teensy, to improve reliability when
-///              poor wiring is in use.<br>
-///              on some devices such as Teensy.<br>
-///              Tested RH_NRF24 examples with Teensy 3.1: they now run out of the box.<br>
-/// \version 1.5 2014-04-29<br>
-///              Added support for Nordic Semiconductor nRF905 transceiver with RH_NRF905 driver. Also
-///              added examples for nRF905 and tested on Teensy 3.1
-/// \version 1.6 2014-04-30<br>
-///              NRF905 examples were missing
-/// \version 1.7 2014-05-03<br>
-///              Added support for Arduino Due. Tested with RH_NRF905, RH_Serial, RH_ASK.
-///              IMPORTANT CHANGE to interrupt pins on Arduino with RH_RF22 and RH_RF69 constructors:
-///              previously, you had to specify the interrupt _number_ not the interrupt _pin_. Arduinos and Uno32
-///              are now consistent with all other platforms: you must specify the interrupt pin number. Default
-///              changed to pin 2 (a common choice with RF22 shields).
-///              Removed examples/maple/maple_rf22_reliable_datagram_client and 
-///              examples/maple/maple_rf22_reliable_datagram_client since the rf22 examples now work out
-///              of the box with Flymaple.
-///              Removed examples/uno32/uno32_rf22_reliable_datagram_client and 
-///              examples/uno32/uno32_rf22_reliable_datagram_client since the rf22 examples now work out
-///              of the box with ChipKit Uno32.
-/// \version 1.8 2014-05-08 <br>
-///              Added support for YIELD in Teensy 2 and 3, suggested by Steve Childress.<br>
-///              Documentation updates. Clarify use of headers and Flags<br>
-///              Fixed misalignment in RH_RF69 between ModemConfigChoice definitions and the implemented choices
-///              which meant you didnt get the choice you thought and GFSK_Rb55555Fd50 hung the transmitter.<br>
-///              Preliminary work on Linux simulator.
-/// \version 1.9 2014-05-14 <br>
-///              Added support for using Timer 2 instead of Timer 1 on Arduino in RH_ASK when
-///              RH_ASK_ARDUINO_USE_TIMER2 is defined. With the kind assistance of
-///              Luc Small. Thanks!<br>
-///              Updated comments in RHReliableDatagram concerning servers, retries, timeouts and delays.
-///              Fixed an error in RHReliableDatagram where recvfrom return value was not checked.
-///              Reported by Steve Childress.<br>
-///              Added Linux simulator support so simple RadioHead sketches can be compiled and run on Linux.<br>
-///              Added RH_TCP driver to permit message passing between simulated sketches on Linux.<br>
-///              Added example simulator sketches.<br>
-///              Added tools/etherSimulator.pl, a simulator of the 'Luminiferous Ether' that passes
-///              messages between simulated sketches and can simulate random message loss etc.<br>
-///              Fixed a number of typos and improved some documentation.<br>
-/// \version 1.10 2014-05-15 <br>
-///              Added support for RFM73 modules to RH_NRF24. These 2 radios are very similar, and can interoperate
-///              with each other. Added new RH_NRF24::TransmitPower enums for the RFM73, which has a different 
-///              range of available powers<br>
-///              reduced the default SPI bus speed for RH_NRF24 to 1MHz, since so many modules and CPU have problems
-///              with 8MHz.<br>
-/// \version 1.11 2014-05-18<br>
-///              Testing RH_RF22 with RFM23BP and 3.3V Teensy 3.1 and 5V Arduinos. 
-///              Updated documentation with respect to GPIO and antenna
-///              control pins for RFM23. Updated documentation with respect to transmitter power control for RFM23<br>
-///              Fixed a problem with RH_RF22 driver, where GPIO TX and RX pins were not configured during
-///              initialisation, causing poor transmit power and sensitivity on those RF22/RF23 devices where GPIO controls
-///              the antenna selection pins.
-/// \version 1.12 2014-05-20<br>
-///              Testing with RF69HW and the RH_RF69 driver. Works well with the Anarduino MiniWireless -CW and -HW 
-///              boards http://www.anarduino.com/miniwireless/ including
-///              the marvellous high powered MinWireless-HW (with 20dBm output for excellent range).<br>
-///              Clarified documentation of RH_RF69::setTxPower values for different models of RF69.<br>
-///              Added RHReliableDatagram::resetRetransmissions().<br>
-///              Retransmission count precision increased to uin32_t.<br>
-///              Added data about actual power measurements from RFM22 module.<br>
-/// \version 1.13 2014-05-23<br>
-///              setHeaderFlags(flags) changed to setHeaderFlags(set, clear), enabling any flags to be
-///              individually set and cleared by either RadioHead or application code. Requested by Steve Childress.<br>
-///              Fixed power output setting for boost power on RF69HW for 18, 19 and 20dBm.<br>
-///              Added data about actual power measurements from RFM69W and RFM69HW modules.<br>
-/// \version 1.14 2014-05-26<br>
-///              RH_RF69::init() now always sets the PA boost back to the default settings, else can get invalid
-///              PA power modes after uploading new sketches without a power cycle. Reported by Bryan.<br>
-///              Added new macros RH_VERSION_MAJOR RH_VERSION_MINOR, with automatic maintenance in Makefile.<br>
-///              Improvements to RH_TCP: constructor now honours the server argument in the form "servername:port".<br>
-///              Added YIELD to RHReliableDatagram::recvfromAckTimeout. Requested by Steve Childress.<br>
-///              Fixed a problem with RH_RF22 reliable datagram acknowledgements that was introduced in version 1.13.
-///              Reported by Steve Childress.<br>
-/// \version 1.15 2014-05-27<br>
-///              Fixed a problem with the RadioHead .zip link.
-/// \version 1.16 2014-05-30 <br>
-///              Fixed RH_RF22 so that lastRssi() returns the signal strength in dBm. Suggested by Steve Childress.<br>
-///              Added support for getLastPreambleTime() to RH_RF69. Requested by Steve Childress.<br>
-///              RH_NRF24::init() now checks if there is a device connected and responding, else init() will fail.
-///              Suggested by Steve Brown.<br>
-///              RHSoftwareSPI now initialises default values for SPI pins MOSI = 12, MISO = 11 and SCK = 13.<br>
-///              Fixed some problems that prevented RH_NRF24 working with mixed software and hardware SPI 
-///              on different devices: a race condition
-///              due to slow SPI transfers and fast acknowledgement.<br>
-/// \version 1.17 2014-06-02 <br>
-///              Fixed a debug typo in RHReliableDatagram that was introduced in 1.16.<br>
-///              RH_NRF24 now sets default power, data rate and channel in init(), in case another
-///              app has previously set different values without powerdown.<br>
-///              Caution: there are still problems with RH_NRF24 and Software SPI. Do not use.<br>
-/// \version 1.18 2014-06-02<br>
-///              Improvements to performance of RH_NRF24 statusRead, allowing RH_NRF24 and Software SPI
-///              to operate on slow devices like Arduino Uno.<br>
-/// \version 1.19 2014-06-19<br>
-///              Added examples ask_transmitter.pde and ask_receiver.pde.<br>
-///              Fixed an error in the RH_RF22 doc for connection of Teensy to RF22.<br>
-///              Improved documentation of start symbol bit patterns in RH_ASK.cpp
-/// \version 1.20 2014-06-24<br>
-///              Fixed a problem with compiling on platforms such as ATTiny where SS is not defined.<br>
-///              Added YIELD to RHMesh::recvfromAckTimeout().<br>
-/// \version 1.21 2014-06-24<br>
-///              Fixed an issue in RH_Serial where characters might be lost with back-to-back frames.
-///              Suggested by Steve Childress.<br>
-///              Brought previous RHutil/crc16.h code into mainline RHCRC.cpp to prevent name collisions
-///              with other similarly named code in other libraries. Suggested by Steve Childress.<br>
-///              Fix SPI bus speed errors on 8MHz Arduinos.
-/// \version 1.22 2014-07-01<br>
-///              Update RH_ASK documentation for common wiring connections.<br>
-///              Testing RH_ASK with HopeRF RFM83C/RFM85 courtesy Anarduino http://www.anarduino.com/<br>
-///              Testing RH_NRF24 with Itead Studio IBoard Pro http://imall.iteadstudio.com/iboard-pro.html
-///              using both hardware SPI on the ITDB02 Parallel LCD Module Interface pins and software SPI
-///              on the nRF24L01+ Module Interface pins. Documented wiring required.<br>
-///              Added support for AVR 1284 and 1284p, contributed by Peter Scargill.
-///              Added support for Semtech SX1276/77/78 and HopeRF RFM95/96/97/98 and other similar LoRa capable radios
-///              in LoRa mode only. Tested with the excellent MiniWirelessLoRa from 
-///              Anarduino http://www.anarduino.com/miniwireless<br>
-/// \version 1.23 2014-07-03<br>
-///              Changed the default modulation for RH_RF69 to GFSK_Rb250Fd250, since the previous default
-///              was not very reliable.<br>
-///              Documented RH_RF95 range tests.<br>
-///              Improvements to RH_RF22 RSSI readings so that lastRssi correctly returns the last message in dBm.<br>
-/// \version 1.24 2014-07-18
-///              Added support for building RadioHead for STM32F4 Discovery boards, using the native STM Firmware libraries,
-///              in order to support Codec2WalkieTalkie (http://www.airspayce.com/mikem/Codec2WalkieTalkie)
-///              and other projects. See STM32ArduinoCompat.<br>
-///              Default modulation for RH_RF95 was incorrectly set to a very slow Bw125Cr48Sf4096
-/// \version 1.25 2014-07-25
-///              The available() function will longer terminate any current transmission, and force receive mode. 
-///              Now, if there is no unprocessed incoming message and an outgoing message is currently being transmitted, 
-///              available() will return false.<br>
-///              RHRouter::sendtoWait(uint8_t*, uint8_t, uint8_t, uint8_t) renamed to sendtoFromSourceWait due to conflicts
-///              with new sendtoWait() with optional flags.<br>
-///              RHMEsh and RHRouter already supported end-to-end application layer flags, but RHMesh::sendtoWait() 
-///              and RHRouter::sendToWait have now been extended to expose a way to send optional application layer flags.
-/// \version 1.26 2014-08-12
-///              Fixed a Teensy 2.0 compile problem due yield() not available on Teensy < 3.0. <br>
-///              Adjusted the algorithm of RH_RF69::temperatureRead() to more closely reflect reality.<br>
-///              Added functions to RHGenericDriver to get driver packet statistics: rxBad(), rxGood(), txGood().<br>
-///              Added RH_RF69::printRegisters().<br>
-///              RH_RF95::printRegisters() was incorrectly printing the register index instead of the address.
-///              Reported by Phang Moh Lim.<br>
-///              RH_RF95, added definitions for some more registers that are usable in LoRa mode.<br>
-///              RH_RF95::setTxPower now uses RH_RF95_PA_DAC_ENABLE to achieve 21, 22 and 23dBm.<br>
-///              RH_RF95, updated power output measurements.<br>
-///              Testing RH_RF69 on Teensy 3.1 with RF69 on PJRC breakout board. OK.<br>
-///              Improvements so RadioHead will build under Arduino where SPI is not supported, such as 
-///              ATTiny.<br>
-///              Improvements so RadioHead will build for ATTiny using Arduino IDE and tinycore arduino-tiny-0100-0018.zip.<br>
-///              Testing RH_ASK on ATTiny85. Reduced RAM footprint. 
-///              Added helpful documentation. Caution: RAM memory is *very* tight on this platform.<br>
-///              RH_RF22 and RH_RF69, added setIdleMode() function to allow the idle mode radio operating state
-///              to be controlled for lower idle power consumption at the expense of slower transitions to TX and RX.<br>
-/// \version 1.27 2014-08-13
-///              All RH_RF69 modulation schemes now have data whitening enabled by default.<br>
-///              Tested and added a number of OOK modulation schemes to RH_RF69 Modem config table.<br>
-///              Minor improvements to a number of the faster RH_RF69 modulation schemes, but some slower ones
-///              are still not working correctly.<br>
-/// \version 1.28 2014-08-20
-///              Added new RH_RF24 driver to support Si446x, RF24/26/26, RFM24/26/27 family of transceivers.
-///              Tested with the excellent
-///              Anarduino Mini and RFM24W and RFM26W with the generous assistance of the good people at 
-///              Anarduino http://www.anarduino.com.
-/// \version 1.29 2014-08-21
-///              Fixed a compile error in RH_RF24 introduced at the last minute in hte previous release.<br>
-///              Improvements to RH_RF69 modulation schemes: now include the AFCBW in teh ModemConfig.<br>
-///              ModemConfig RH_RF69::FSK_Rb2Fd5 and RH_RF69::GFSK_Rb2Fd5 are now working.<br> 
-/// \version 1.30 2014-08-25
-///              Fixed some compile problems with ATtiny84 on Arduino 1.5.5 reported by Glen Cook.<br>
-/// \version 1.31 2014-08-27
-///              Changed RH_RF69 FSK and GFSK modulations from Rb2_4Fd2_4 to Rb2_4Fd4_8 and FSK_Rb4_8Fd4_8 to FSK_Rb4_8Fd9_6
-///              since the previous ones were unreliable (they had modulation indexes of 1).<br>
-/// \version 1.32 2014-08-28
-///              Testing with RedBearLab Blend board http://redbearlab.com/blend/. OK.<br>
-///              Changed more RH_RF69 FSK and GFSK slowish modulations to have modulation index of 2 instead of 1. 
-///              This required chnaging the symbolic names.<br>
-/// \version 1.33 2014-09-01
-///              Added support for sleep mode in RHGeneric driver, with new mode 
-///              RHModeSleep and new virtual function sleep().<br>
-///              Added support for sleep to RH_RF69, RH_RF22, RH_NRF24, RH_RF24, RH_RF95 drivers.<br>
-/// \version 1.34 2014-09-19
-///              Fixed compile errors in example rf22_router_test.<br>
-///              Fixed a problem with RH_NRF24::setNetworkAddress, also improvements to RH_NRF24 register printing.
-///              Patched by Yveaux.<br>
-///              Improvements to RH_NRF24 initialisation for version 2.0 silicon.<br>
-///              Fixed problem with ambigiguous print call in RH_RFM69 when compiling for Codec2.<br>
-///              Fixed a problem with RH_NRF24 on RFM73 where the LNA gain was not set properly, reducing the sensitivity
-///              of the receiver.
-/// \version 1.35 2014-09-19
-///              Fixed a problem with interrupt setup on RH_RF95 with Teensy3.1. Reported by AD.<br>
-/// \version 1.36 2014-09-22
-///              Improvements to interrupt pin assignments for __AVR_ATmega1284__ and__AVR_ATmega1284P__, provided by
-///              Peter Scargill.<br>
-///              Work around a bug in Arduino 1.0.6 where digitalPinToInterrupt is defined but NOT_AN_INTERRUPT is not.<br>
-///  \version 1.37 2014-10-19
-///              Updated doc for connecting RH_NRF24 to Arduino Mega.<br>
-///              Changes to RHGenericDriver::setHeaderFlags(), so that the default for the clear argument
-///              is now RH_FLAGS_APPLICATION_SPECIFIC, which is less surprising to users.
-///              Testing with the excellent MoteinoMEGA from LowPowerLab 
-///              https://lowpowerlab.com/shop/moteinomega with on-board RFM69W.
-///  \version 1.38 2014-12-29
-///              Fixed compile warning on some platforms where RH_RF24::send and RH_RF24::writeTxFifo 
-///              did not return a value.<br>
-///              Fixed some more compiler warnings in RH_RF24 on some platforms.<br>
-///              Refactored printRegisters for some radios. Printing to Serial
-///              is now controlled by the definition of RH_HAVE_SERIAL.<br>
-///              Added partial support for ARM M4 w/CMSIS with STM's Hardware Abstraction lib for 
-///              Steve Childress.<br>
-///  \version 1.39 2014-12-30
-///              Fix some compiler warnings under IAR.<br>
-///              RH_HAVE_SERIAL and Serial.print calls removed for ATTiny platforms.<br>
-///  \version 1.40 2015-03-09
-///              Added notice about availability on PlatformIO, thanks to Ivan Kravets.<br>
-///              Fixed a problem with RH_NRF24 where short packet lengths would occasionally not be trasmitted
-///              due to a race condition with RH_NRF24_TX_DS. Reported by Mark Fox.<br>
-///  \version 1.41 2015-03-29
-///              RH_RF22, RH_RF24, RH_RF69 and RH_RF95 improved to allow driver.init() to be called multiple
-///              times without reallocating a new interrupt, allowing the driver to be reinitialised
-///              after sleeping or powering down.
-///  \version 1.42 2015-05-17
-///              Added support for RH_NRF24 driver on Raspberry Pi, using BCM2835
-///              library for GPIO pin IO. Contributed by Mike Poublon.<br>
-///              Tested RH_NRF24 module with NRF24L01+PA+LNA SMA Antenna Wireless Transceiver modules
-///              similar to: http://www.elecfreaks.com/wiki/index.php?title=2.4G_Wireless_nRF24L01p_with_PA_and_LNA
-///              works with no software changes. Measured max power output 18dBm.<br>
-///  \version 1.43 2015-08-02
-///              Added RH_NRF51 driver to support Nordic nRF51 family processor with 2.4GHz radio such 
-///              as nRF51822, to be built on Arduino 1.6.4 and later. Tested with RedBearLabs nRF51822 board
-///              and BLE Nano kit<br>
-///  \version 1.44 2015-08-08
-///              Fixed errors with compiling on some platforms without serial, such as ATTiny. 
-///              Reported by Friedrich Müller.<br>
-///  \version 1.45 2015-08-13
-///              Added support for using RH_Serial on Linux and OSX (new class RHutil/HardwareSerial
-///              encapsulates serial ports on those platforms). Example examples/serial upgraded
-///              to build and run on Linux and OSX using the tools/simBuild builder.
-///              RHMesh, RHRouter and RHReliableDatagram updated so they can use RH_Serial without
-///              polling loops on Linux and OSX for CPU efficiency.<br>
-///  \version 1.46 2015-08-14
-///              Amplified some doc concerning Linux and OSX RH_Serial. Added support for 230400
-///              baud rate in HardwareSerial.<br>
-///              Added sample sketches nrf51_audio_tx and nrf51_audio_rx which show how to
-///              build an audio TX/RX pair with RedBear nRF51822 boards and a SparkFun MCP4725 DAC board.
-///              Uses the built-in ADC of the nRF51822 to sample audio at 5kHz and transmit packets
-///              to the receiver which plays them via the DAC.<br>
-/// \version 1.47 2015-09-18
-///              Removed top level Makefile from distribution: its only used by the developer and 
-///              its presence confuses some people.<br>
-///              Fixed a problem with RHReliableDatagram with some versions of Raspberry Pi random() that causes 
-///              problems: random(min, max) sometimes exceeds its max limit.
-/// \version 1.48 2015-09-30
-///              Added support for Arduino Zero. Tested on Arduino Zero Pro.
-/// \version 1.49 2015-10-01
-///              Fixed problems that prevented interrupts working correctly on Arduino Zero and Due.
-///              Builds and runs with 1.6.5 (with 'Arduino SAMD Boards' for Zero version 1.6.1) from arduino.cc.
-///              Arduino version 1.7.7 from arduino.org is not currently supported.
-/// \version 1.50 2015-10-25
-///              Verified correct building and operation with Arduino 1.7.7 from arduino.org.
-///              Caution: You must burn the bootloader from 1.7.7 to the Arduino Zero before it will 
-///              work with Arduino 1.7.7 from arduino.org. Conversely, you must burn the bootloader from 1.6.5 
-///              to the Arduino Zero before it will 
-///              work with Arduino 1.6.5 from arduino.cc. Sigh.
-///              Fixed a problem with RH_NRF905 that prevented the power and frequency ranges being set
-///              properly. Reported by Alan Webber.
-/// \version 1.51 2015-12-11
-///              Changes to RH_RF6::setTxPower() to be compatible with SX1276/77/78/79 modules that
-///              use RFO transmitter pins instead of PA_BOOST, such as the excellent
-///              Modtronix inAir4 http://modtronix.com/inair4.html 
-///              and inAir9 modules http://modtronix.com/inair9.html. With the kind assistance of 
-///              David from Modtronix.
-/// \version 1.52 2015-12-17
-///              Added RH_MRF89 module to suport Microchip MRF89XA and compatible transceivers.
-///              and modules.<br>
-/// \version 1.53 2016-01-02
-///              Added RH_CC110 module to support Texas Instruments CC110L and compatible transceivers and modules.<br>
-/// \version 1.54 2016-01-29
-///              Added support for ESP8266 processor on Arduino IDE. Examples serial_reliable_datagram_* are shown to work. 
-///              CAUTION: SPI not supported yet. Timers used by RH_ASK are not tested. 
-///              The GHz radio included in the ESP8266 is not yet supported. 
-/// \version 1.55 2016-02-12
-///              Added macros for htons() and friends to RadioHead.h.
-///              Added example sketch serial_gateway.pde. Acts as a transparent gateway between RH_RF22 and RH_Serial, 
-///              and with minor mods acts as a universal gateway between any 2 RadioHead driver networks.
-///              Initial work on supporting STM32 F2 on Particle Photon: new platform type defined.
-///              Fixed many warnings exposed by test building for Photon.
-///              Particle Photon tested support for RH_Serial, RH_ASK, SPI, RH_CC110 etc.
-///              Added notes on how to build RadioHead sketches for Photon.
-/// \version 1.56 2016-02-18 
-///              Implemented timers for RH_ASK on ESP8266, added some doc on IO pin selection.
-/// \version 1.57 2016-02-23
-///              Fixed an issue reported by S3B, where RH_RF22 would sometimes not clear the rxbufvalid flag.
-/// \version 1.58 2-16-04-04
-///              Tested RH_RF69 with Arduino Due. OK. Updated doc.<br>
-///              Added support for all ChipKIT Core supported boards 
-///              http://chipkit.net/wiki/index.php?title=ChipKIT_core
-///              Tested on ChipKIT Uno32.<br>
-///              Digilent Uno32 under the old MPIDE is no longer formally 
-///              supported but may continue to work for some time.<br>
-/// \version 1.59 2016-04-12
-///              Testing with the excellent Rocket Scream Mini Ultra Pro with the RFM95W and RFM69HCW modules from
-///              http://www.rocketscream.com/blog/product/mini-ultra-pro-with-radio/  (915MHz versions). Updated
-///              documentation with hints to suit. Caution: requires Arduino 1.6.8 and Arduino SAMD Boards 1.6.5.
-///              See also http://www.rocketscream.com/blog/2016/03/10/radio-range-test-with-rfm69hcw/
-///              for the vendors tests and range with the RFM69HCW version. They also have an RF95 version equipped with
-///              TCXO temperature controllled oscillator for extra frequency stability and support of very slow and
-///              long range protocols.
-///              These boards are highly recommended. They also include battery charging support.
-/// \version 1.60 2016-06-25
-///              Tested with the excellent talk2 Whisper Node boards 
-///             (https://talk2.wisen.com.au/ and https://bitbucket.org/talk2/), 
-///              an Arduino Nano compatible board, which include an on-board RF69 radio, external antenna, 
-///              run on 2xAA batteries and support low power operations. RF69 examples work without modification.
-///              Added support for ESP8266 SPI, provided by David Skinner.
-/// \version 1.61 2016-07-07
-///              Patch to RH_ASK.cpp for ESP8266, to prevent crashes in interrupt handlers. Patch from Alexander Mamchits.
-/// \version 1.62 2016-08-17
-///              Fixed a problem in RH_ASK where _rxInverted was not properly initialised. Reported by "gno.sun.sop".
-///              Added support for  waitCAD() and isChannelActive() and setCADTimeout() to RHGeneric.
-///              Implementation of RH_RF95::isChannelActive() allows the RF95 module to support
-///              Channel Activity Detection (CAD). Based on code contributed by Bent Guldbjerg Christensen.
-///              Implmentations of isChannelActive() plus documentation for other radio modules wil be welcomed.
-/// \version 1.63 2016-10-20
-///              Testing with Adafruit Feather 32u4 with RFM69HCW. Updated documentation to reflect.<br>
-/// \version 1.64 2016-12-10
-///              RHReliableDatagram now initialises _seenids. Fix from Ben Lim.<br>
-///              In RH_NRF51, added get_temperature().<br>
-///              In RH_NRF51, added support for AES packet encryption, which required a slight change 
-///              to the on-air message format.<br>
-/// \version 1.65 2017-01-11
-///              Fixed a race condition with RH_NRF51 that prevented ACKs being reliably received.<br>
-///              Removed code in RH_NRF51 that enabled the DC-DC converter. This seems not to be a necessary condition
-///              for the radio to work and is now left to the application if that is required.<br>
-///              Proven interoperation between nRF51822 and nRF52832.<br>
-///              Modification and testing of RH_NRF51 so it works with nRF52 family processors,
-///              such Sparkfun nRF52832 breakout board, with Arduino 1.6.13 and
-///              Sparkfun nRF52 boards manager 0.2.3 using the procedures outlined in
-///              https://learn.sparkfun.com/tutorials/nrf52832-breakout-board-hookup-guide<br>
-///              Caution, the Sparkfun development system for Arduino is still immature. We had to 
-///              rebuild the nrfutil program since the supplied one was not suitable for 
-///              the Linux host we were developing on. See https://forum.sparkfun.com/viewtopic.php?f=32&t=45071
-///              Also, after downloading a sketch in the nRF52832, the program does not start executing cleanly: 
-///              you have to reset the processor again by pressing the reset button. 
-///              This appears to be a problem with nrfutil, rather than a bug in RadioHead.
-/// \version 1.66 2017-01-15
-///              Fixed some errors in (unused) register definitions in RH_RF95.h.<br>
-///              Fixed a problem that caused compilation errors in RH_NRF51 if the appropriate board 
-///              support was not installed.
-/// \version 1.67 2017-01-24
-///              Added RH_RF95::frequencyError() to return the estimated centre frequency offset in Hz 
-///              of the last received message
-/// \version 1.68 2017-01-25
-///              Fixed arithmetic error in RH_RF95::frequencyError() for some platforms.
-/// \version 1.69 2017-02-02
-///              Added RH_RF95::lastSNR() and improved lastRssi() calculations per the manual.
-/// \version 1.70 2017-02-03
-///              Added link to Binpress commercial license purchasing.
-/// \version 1.71 2017-02-07
-///              Improved support for STM32. Patch from Bent Guldbjerg Christensen.
-/// \version 1.72 2017-03-02
-///              In RH_RF24, fixed a problem where some important properties were not set by the ModemConfig.
-///              Added properties 2007, 2008, 2009. Also properties 200a was not being set in the chip.
-///              Reported by Shannon Bailey and Alan Adamson.
-///              Fixed corresponding convert.pl and added it to the distribution.
-/// \version 1.73 2017-03-04
-///              Significant changes to RH_RF24 and its API. It is no longer possible to change the modulation scheme
-///              programatically: it proved impossible to cater for all the possible crystal frequencies,
-///              base frequency and modulation schemes. Instead you can use one of a small set of supplied radio
-///              configuration header files, or generate your own with Silicon Labs WDS application. Changing
-///              modulation scheme required editing RH_RF24.cpp to specify the appropriate header and recompiling.
-///              convert.pl is now redundant and removed from the distribution.
-/// \version 1.74 2017-03-08
-///              Changed RHReliableDatagram so it would not ACK messages heard addressed to other nodes
-///              in promiscuous mode.<br>
-///              Added RH_RF24::deviceType() to return the integer value of the connected device.<br>
-///              Added documentation about how to connect RFM69 to an ESP8266. Tested OK.<br>
-///              RH_RF24 was not correctly changing state in sleep() and setModeIdle().<br>
-///              Added example rf24_lowpower_client.pde showing how to put an arduino and radio into a low power
-///              mode between transmissions to save battery power.<br>
-///              Improvements to RH_RF69::setTxPower so it now takes an optional ishighpowermodule
-///              flag to indicate if the connected module is a high power RFM69HW, and so set the power level
-///              correctly. Based on code contributed by bob.
-/// \version 1.75 2017-06-22
-///              Fixed broken compiler issues with RH_RF95::frequencyError() reported by Steve Rogerson.<br>
-///              Testing with the very excellent Rocket Scream boards equipped with RF95 TCXO modules. The
-///              temperature controlled oscillator stabilises the chip enough to be able to use even the slowest
-///              protocol Bw125Cr48Sf4096. Caution, the TCXO model radios are not low power when in sleep (consuming
-///              about ~600 uA, reported by Phang Moh Lim).<br>
-///              Added support for EBYTE E32-TTL-1W and family serial radio transceivers. These RF95 LoRa based radios
-///              can deliver reliable messages at up to 7km measured.
-/// \version 1.76 2017-06-23
-///              Fixed a problem with RH_RF95 hanging on transmit under some mysterious circumstances.
-///              Reported by several people at  https://forum.pjrc.com/threads/41878-Probable-race-condition-in-Radiohead-library?p=146601#post146601 <br>
-///              Increased the size of rssi variables to 16 bits to permit RSSI less than -128 as reported by RF95.
-/// \version 1.77 2017-06-25
-///              Fixed a compilation error with lastRssi().<br>
-/// \version 1.78 2017-07-19
-///              Fixed a number of unused variable warnings from g++.<br>
-///              Added new module RHEncryptedDriver and examples, contributed by Philippe Rochat, which
-///              adds encryption and decryption to any RadioHead transport driver, using any encryption cipher
-///              supported by ArduinoLibs Cryptographic Library http://rweather.github.io/arduinolibs/crypto.html
-///              Includes several examples.<br>
-/// \version 1.79 2017-07-25
-///              Added documentation about 'Passing Sensor Data Between RadioHead nodes'.<br>
-///              Changes to RH_CC110 driver to calculate RSSI in dBm, based on a patch from Jurie Pieterse.<br>
-///              Added missing passthroughmethoids to RHEncryptedDriver, allowing it to be used with RHDatagram,
-///              RHReliableDatagram etc. Tested with RH_Serial. Added examples 
-/// \version 1.80 2017-10-04
-///              Testing with the very fine Talk2 Whisper Node LoRa boards https://wisen.com.au/store/products/whisper-node-lora
-///              an Arduino compatible board, which include an on-board RFM95/96 LoRa Radio (Semtech SX1276), external antenna, 
-///              run on 2xAAA batteries and support low power operations. RF95 examples work without modification.
-///              Use Arduino Board Manager to install the Talk2 code support. Upload the code with an FTDI adapter set to 5V.<br>
-///              Added support for SPI transactions in development environments that support it with SPI_HAS_TRANSACTION.
-///              Tested on ESP32 with RFM-22 and Teensy 3.1 with RF69
-///              Added support for ESP32, tested with RFM-22 connected by SPI.<br>
-///\version 1.81 2017-11-15
-///              RH_CC110, moved setPaTable() from protected to public.<br>
-///              RH_RF95 modem config Bw125Cr48Sf4096 altered to enable slow daat rate in register 26
-///              as suggested by Dieter Kneffel.
-///              Added support for nRF52 compatible Arm chips such as as Adafruit BLE Feather board
-///              https://www.adafruit.com/product/3406, with a patch from Mike Bell.<br>
-///              Fixed a problem where rev 1.80 broke Adafruit M0 LoRa support by declaring 
-///              bitOrder variable always as a unsigned char. Reported by Guilherme Jardim.<br>
-///              In RH_RF95, all modes now have AGC enabled, as suggested by Dieter Kneffel.<br>
-/// \version 1.82 2018-01-07
-///              Added guard code to RH_NRF24::waitPacketSent() so that if the transmit never completes for some
-///              reason, the code will eventually return with FALSE.
-///              Added the low-datarate-optimization bit to config for RH_RF95::Bw125Cr48Sf4096.
-///              Fix from Jurie Pieterse to ensure RH_CC110::sleep always enters sleep mode.
-///              Update ESP32 support to include ASK timers. RH_ASK module is now working on ESP32.
-///
-/// \author  Mike McCauley. DO NOT CONTACT THE AUTHOR DIRECTLY. USE THE GOOGLE LIST GIVEN ABOVE
+/*! \mainpage RadioHead Packet Radio library for embedded microprocessors
+
+This is the RadioHead Packet Radio library for embedded microprocessors.
+It provides a complete object-oriented library for sending and receiving packetized messages
+via a variety of common data radios and other transports on a range of embedded microprocessors.
+
+The version of the package that this documentation refers to can be downloaded 
+from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.83.zip
+You can find the latest version of the documentation at http://www.airspayce.com/mikem/arduino/RadioHead
+
+You can also find online help and discussion at 
+http://groups.google.com/group/radiohead-arduino
+Please use that group for all questions and discussions on this topic. 
+Do not contact the author directly, unless it is to discuss commercial licensing.
+Before asking a question or reporting a bug, please read 
+- http://en.wikipedia.org/wiki/Wikipedia:Reference_desk/How_to_ask_a_software_question
+- http://www.catb.org/esr/faqs/smart-questions.html
+- http://www.chiark.greenend.org.uk/~shgtatham/bugs.html
+
+Caution: Developing this type of software and using data radios
+successfully is challenging and requires a substantial knowledge
+base in software and radio and data transmission technologies and
+theory.  It may not be an appropriate project for beginners. If
+you are a beginner, you will need to spend some time gaining
+knowledge in these areas first.
+
+\par Overview
+
+RadioHead consists of 2 main sets of classes: Drivers and Managers.
+
+- Drivers provide low level access to a range of different packet radios and other packetized message transports.
+- Managers provide high level message sending and receiving facilities for a range of different requirements.
+
+Every RadioHead program will have an instance of a Driver to
+provide access to the data radio or transport, and usually a
+Manager that uses that driver to send and receive messages for the
+application. The programmer is required to instantiate a Driver
+and a Manager, and to initialise the Manager. Thereafter the
+facilities of the Manager can be used to send and receive
+messages.
+
+It is also possible to use a Driver on its own, without a Manager, although this only allows unaddressed, 
+unreliable transport via the Driver's facilities.
+
+In some specialised use cases, it is possible to instantiate more than one Driver and more than one Manager.
+
+A range of different common embedded microprocessor platforms are supported, allowing your project to run
+on your choice of processor.
+
+Example programs are included to show the main modes of use.
+
+\par Drivers
+
+The following Drivers are provided:
+
+- RH_RF22
+Works with Hope-RF
+RF22B and RF23B based transceivers, and compatible chips and modules, 
+including the RFM22B transceiver module such as 
+this bare module: http://www.sparkfun.com/products/10153
+and this shield: http://www.sparkfun.com/products/11018 
+and this board: http://www.anarduino.com/miniwireless
+and RF23BP modules such as: http://www.anarduino.com/details.jsp?pid=130
+Supports GFSK, FSK and OOK. Access to other chip 
+features such as on-chip temperature measurement, analog-digital 
+converter, transmitter power control etc is also provided.
+
+- RH_RF24
+Works with Silicon Labs Si4460/4461/4463/4464 family of transceivers chip, and the equivalent
+HopeRF RF24/26/27 family of chips and the HopeRF RFM24W/26W/27W modules.
+Supports GFSK, FSK and OOK. Access to other chip 
+features such as on-chip temperature measurement, analog-digital 
+converter, transmitter power control etc is also provided.
+
+- RH_RF69 
+Works with Hope-RF
+RF69B based radio modules, such as the RFM69 module, (as used on the excellent Moteino and Moteino-USB 
+boards from LowPowerLab http://lowpowerlab.com/moteino/ )
+and compatible chips and modules such as RFM69W, RFM69HW, RFM69CW, RFM69HCW (Semtech SX1231, SX1231H).
+Also works with Anarduino MiniWireless -CW and -HW boards http://www.anarduino.com/miniwireless/ including
+the marvellous high powered MinWireless-HW (with 20dBm output for excellent range).
+Supports GFSK, FSK.
+
+- RH_NRF24
+Works with Nordic nRF24 based 2.4GHz radio modules, such as nRF24L01 and others.
+Also works with Hope-RF RFM73 
+and compatible devices (such as BK2423). nRF24L01 and RFM73 can interoperate
+with each other.
+
+- RH_NRF905
+Works with Nordic nRF905 based 433/868/915 MHz radio modules.
+
+- RH_NRF51
+Works with Nordic nRF51 compatible 2.4 GHz SoC/devices such as the nRF51822.
+Also works with Sparkfun nRF52832 breakout board, with Arduino 1.6.13 and
+Sparkfun nRF52 boards manager 0.2.3
+
+- RH_RF95
+Works with Semtech SX1276/77/78/79, Modtronix inAir4 and inAir9,
+and HopeRF RFM95/96/97/98 and other similar LoRa capable radios.
+Supports Long Range (LoRa) with spread spectrum frequency hopping, large payloads etc.
+FSK/GFSK/OOK modes are not (yet) supported.
+
+- RH_MRF89
+Works with Microchip MRF89XA and compatible transceivers.
+and modules such as MRF89XAM9A.
+
+- RH_CC110
+Works with Texas Instruments CC110L transceivers and compatible modules such as
+Anaren AIR BoosterPack 430BOOST-CC110L
+
+- RH_E32
+Works with EBYTE E32-TTL-1W serial radio transceivers (and possibly other transceivers in the same family)
+
+- RH_ASK
+Works with a range of inexpensive ASK (amplitude shift keying) RF transceivers such as RX-B1 
+(also known as ST-RX04-ASK) receiver; TX-C1 transmitter and DR3100 transceiver; FS1000A/XY-MK-5V transceiver;
+HopeRF RFM83C / RFM85. Supports ASK (OOK).
+
+- RH_Serial
+Works with RS232, RS422, RS485, RS488 and other point-to-point and multidropped serial connections, 
+or with TTL serial UARTs such as those on Arduino and many other processors,
+or with data radios with a 
+serial port interface. RH_Serial provides packetization and error detection over any hardware or 
+virtual serial connection. Also builds and runs on Linux and OSX.
+
+- RH_TCP
+For use with simulated sketches compiled and running on Linux.
+Works with tools/etherSimulator.pl to pass messages between simulated sketches, allowing
+testing of Manager classes on Linux and without need for real radios or other transport hardware.
+
+- RHEncryptedDriver
+Adds encryption and decryption to any RadioHead transport driver, using any encrpytion cipher
+supported by ArduinoLibs Cryptogrphic Library http://rweather.github.io/arduinolibs/crypto.html
+
+Drivers can be used on their own to provide unaddressed, unreliable datagrams. 
+All drivers have the same identical API.
+Or you can use any Driver with any of the Managers described below.
+
+We welcome contributions of well tested and well documented code to support other transports.
+
+\par Managers
+
+The following Managers are provided:
+
+- RHDatagram
+Addressed, unreliable variable length messages, with optional broadcast facilities.
+
+- RHReliableDatagram
+Addressed, reliable, retransmitted, acknowledged variable length messages.
+
+- RHRouter
+Multi-hop delivery of RHReliableDatagrams from source node to destination node via 0 or more
+intermediate nodes, with manual routing.
+
+- RHMesh
+Multi-hop delivery of RHReliableDatagrams with automatic route discovery and rediscovery.
+
+Any Manager may be used with any Driver.
+
+\par Platforms
+
+A range of platforms is supported:
+
+- Arduino and the Arduino IDE (version 1.0 to 1.8.1 and later)
+Including Diecimila, Uno, Mega, Leonardo, Yun, Due, Zero etc. http://arduino.cc/, Also similar boards such as 
+ - Moteino http://lowpowerlab.com/moteino/ 
+ - Anarduino Mini http://www.anarduino.com/mini/ 
+ - RedBearLab Blend V1.0 http://redbearlab.com/blend/ (with Arduino 1.0.5 and RedBearLab Blend Add-On version 20140701) 
+ -  MoteinoMEGA https://lowpowerlab.com/shop/moteinomega 
+    (with Arduino 1.0.5 and the MoteinoMEGA Arduino Core 
+    https://github.com/LowPowerLab/Moteino/tree/master/MEGA/Core)
+ - ESP8266 on Arduino IDE and Boards Manager per https://github.com/esp8266/Arduino 
+   Tested using Arduino 1.6.8 with esp8266 by ESP8266 Community version 2.1.0
+   Examples serial_reliable_datagram_* and ask_* are shown to work. 
+   CAUTION: The GHz radio included in the ESP8266 is
+   not yet supported.
+ - Various Talk2 Whisper boards eg https://wisen.com.au/store/products/whisper-node-lora.
+   Use Arduino Board Manager to install the Talk2 code support. 
+ - etc.
+
+- ChipKIT Core with Arduino IDE on any ChipKIT Core supported Digilent processor (tested on Uno32)
+http://chipkit.net/wiki/index.php?title=ChipKIT_core
+
+- Maple and Flymaple boards with libmaple and the Maple-IDE development environment
+http://leaflabs.com/devices/maple/ and http://www.open-drone.org/flymaple
+
+- Teensy including Teensy 3.1 and earlier built using Arduino IDE 1.0.5 to 1.6.4 and later with 
+  teensyduino addon 1.18 to 1.23 and later.
+  http://www.pjrc.com/teensy
+
+- Particle Photon https://store.particle.io/collections/photon and ARM3 based CPU with built-in 
+  Wi-Fi transceiver and extensive IoT software suport. RadioHead does not support the built-in transceiver
+  but can be used to control other SPI based radios, Serial ports etc.
+  See below for details on how to build RadioHead for Photon
+
+- ATtiny built using Arduino IDE 1.0.5 with the arduino-tiny support from https://code.google.com/p/arduino-tiny/
+  and Digispark built with Arduino 1.6.5.
+  (Caution: these are very small processors and not all RadioHead features may be available, depending on memory requirements)
+
+- nRF51 compatible Arm chips such as nRF51822 with Arduino 1.6.4 and later using the procedures
+  in http://redbearlab.com/getting-started-nrf51822/
+
+- nRF52 compatible Arm chips such as as Adafruit BLE Feather board
+https://www.adafruit.com/product/3406
+
+- Adafruit Feather. These are excellent boards that are available with a variety of radios. We tested with the 
+  Feather 32u4 with RFM69HCW radio, with Arduino IDE 1.6.8 and the Adafruit AVR Boards board manager version 1.6.10.
+  https://www.adafruit.com/products/3076
+//
+- Adafruit Feather M0 boards with Arduino 1.8.1 and later, using the Arduino and Adafruit SAMD board support.
+  https://learn.adafruit.com/adafruit-feather-m0-basic-proto/using-with-arduino-ide
+
+- ESP32 built using Arduino IDE 1.8.1 or later using the ESP32 toolchain installed per
+  https://diyprojects.io/programming-esp32-board-arduino-ide-macos-windows-linux-arm-raspberrypi-orangepi/
+  The internal 2.4GHz radio is not yet supported. Tested with RFM22 using SPI interfcace
+
+- Raspberry Pi
+  Uses BCM2835 library for GPIO http://www.airspayce.com/mikem/bcm2835/
+  Currently works only with RH_NRF24 driver or other drivers that do not require interrupt support.
+  Contributed by Mike Poublon.
+
+- Linux and OSX
+  Using the RHutil/HardwareSerial class, the RH_Serial driver and any manager will
+  build and run on Linux and OSX. These can be used to build programs that talk securely and reliably to
+  Arduino and other processors or to other Linux or OSX hosts on a reliable, error detected datagram
+  protocol over various types of serial line.
+
+Other platforms are partially supported, such as Generic AVR 8 bit processors, MSP430. 
+We welcome contributions that will expand the range of supported platforms. 
+
+RadioHead is available (through the efforts of others) 
+for PlatformIO. PlatformIO is a cross-platform code builder and the missing library manager.
+http://platformio.org/#!/lib/show/124/RadioHead
+
+\par History
+
+RadioHead was created in April 2014, substantially based on code from some of our other earlier Radio libraries:
+
+- RHMesh, RHRouter, RHReliableDatagram and RHDatagram are derived from the RF22 library version 1.39.
+- RH_RF22 is derived from the RF22 library version 1.39.
+- RH_RF69 is derived from the RF69 library version 1.2.
+- RH_ASK is based on the VirtualWire library version 1.26, after significant conversion to C++.
+- RH_Serial was new.
+- RH_NRF24 is based on the NRF24 library version 1.12, with some significant changes.
+
+During this combination and redevelopment, we have tried to retain all the processor dependencies and support from
+the libraries that were contributed by other people. However not all platforms can be tested by us, so if you
+find that support from some platform has not been successfully migrated, please feel free to fix it and send us a 
+patch.
+
+Users of RHMesh, RHRouter, RHReliableDatagram and RHDatagram in the previous RF22 library will find that their
+existing code will run mostly without modification. See the RH_RF22 documentation for more details.
+
+\par Installation
+
+Install in the usual way: unzip the distribution zip file to the libraries
+sub-folder of your sketchbook. 
+The example sketches will be visible in in your Arduino, mpide, maple-ide or whatever.
+http://arduino.cc/en/Guide/Libraries
+
+\par Building for Particle Photon
+
+The Photon is not supported by the Arduino IDE, so it takes a little effort to set up a build environment.
+Heres what we did to enable building of RadioHead example sketches on Linux, 
+but there are other ways to skin this cat.
+Basic reference for getting stated is: http://particle-firmware.readthedocs.org/en/develop/build/
+- Download the ARM gcc cross compiler binaries and unpack it in a suitable place:
+\code
+cd /tmp
+wget https://launchpad.net/gcc-arm-embedded/5.0/5-2015-q4-major/+download/gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2
+tar xvf gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2
+\endcode
+- If dfu-util and friends not installed on your platform, download dfu-util and friends to somewhere in your path
+\code
+cd ~/bin
+wget http://dfu-util.sourceforge.net/releases/dfu-util-0.8-binaries/linux-i386/dfu-util
+wget http://dfu-util.sourceforge.net/releases/dfu-util-0.8-binaries/linux-i386/dfu-suffix
+wget http://dfu-util.sourceforge.net/releases/dfu-util-0.8-binaries/linux-i386/dfu-prefix
+\endcode
+- Download the Particle firmware (contains headers and libraries require to compile Photon sketches) 
+  to a suitable place:
+\code
+cd /tmp
+wget https://github.com/spark/firmware/archive/develop.zip
+unzip develop.zip
+\endcode
+- Make a working area containing the RadioHead library source code and your RadioHead sketch. You must
+  rename the sketch from .pde or .ino to application.cpp
+\code
+cd /tmp
+mkdir RadioHead
+cd RadioHead
+cp /usr/local/projects/arduino/libraries/RadioHead/*.h .
+cp /usr/local/projects/arduino/libraries/RadioHead/*.cpp .
+cp /usr/local/projects/arduino/libraries/RadioHead/examples/cc110/cc110_client/cc110_client.pde application.cpp
+\endcode
+- Edit application.cpp and comment out any \#include <SPI.h> so it looks like:
+\code
+  // #include <SPI.h>
+\endcode
+- Connect your Photon by USB. Put it in DFU mode as descibed in Photon documentation. Light should be flashing yellow
+- Compile the RadioHead sketch and install it as the user program (this does not update the rest of the
+  Photon firmware, just the user part:
+\code
+cd /tmp/firmware-develop/main
+PATH=$PATH:/tmp/gcc-arm-none-eabi-5_2-2015q4/bin make APPDIR=/tmp/RadioHead all PLATFORM=photon program-dfu
+\endcode
+- You should see RadioHead compile without errors and download the finished sketch into the Photon.
+
+\par Compatible Hardware Suppliers
+
+We have had good experiences with the following suppliers of RadioHead compatible hardware:
+
+- LittleBird http://littlebirdelectronics.com.au in Australia for all manner of Arduinos and radios.
+- LowPowerLab http://lowpowerlab.com/moteino in USA for the excellent Moteino and Moteino-USB 
+  boards which include Hope-RF RF69B radios on-board.
+- Anarduino and HopeRF USA (http://www.hoperfusa.com and http://www.anarduino.com) who have a wide range
+  of HopeRF radios and Arduino integrated modules.
+- SparkFun https://www.sparkfun.com/ in USA who design and sell a wide range of Arduinos and radio modules.
+- Wisen http://wisen.com.au who design and sell a wide range of integrated radio/processor modules including the
+  excellent Talk2 range.
+
+\par Coding Style
+
+RadioHead is designed so it can run on small processors with very
+limited resources and strict timing contraints.  As a result, we
+tend only to use the simplest and least demanding (in terms of memory and CPU) C++
+facilities. In particular we avoid as much as possible dynamic
+memory allocation, and the use of complex objects like C++
+strings, IO and buffers. We are happy with this, but we are aware
+that some people may think we are leaving useful tools on the
+table. You should not use this code as an example of how to do
+generalised C++ programming on well resourced processors.
+
+\par Donations
+
+This library is offered under a free GPL license for those who want to use it that way. 
+We try hard to keep it up to date, fix bugs
+and to provide free support. If this library has helped you save time or money, please consider donating at
+http://www.airspayce.com or here:
+
+\htmlonly <form action="https://www.paypal.com/cgi-bin/webscr" method="post"><input type="hidden" name="cmd" value="_donations" /> <input type="hidden" name="business" value="mikem@airspayce.com" /> <input type="hidden" name="lc" value="AU" /> <input type="hidden" name="item_name" value="Airspayce" /> <input type="hidden" name="item_number" value="RadioHead" /> <input type="hidden" name="currency_code" value="USD" /> <input type="hidden" name="bn" value="PP-DonationsBF:btn_donateCC_LG.gif:NonHosted" /> <input type="image" alt="PayPal — The safer, easier way to pay online." name="submit" src="https://www.paypalobjects.com/en_AU/i/btn/btn_donateCC_LG.gif" /> <img alt="" src="https://www.paypalobjects.com/en_AU/i/scr/pixel.gif" width="1" height="1" border="0" /></form> \endhtmlonly
+
+\subpage packingdata "Passing Sensor Data Between RadioHead nodes"
+
+\par Trademarks
+
+RadioHead is a trademark of AirSpayce Pty Ltd. The RadioHead mark was first used on April 12 2014 for
+international trade, and is used only in relation to data communications hardware and software and related services.
+It is not to be confused with any other similar marks covering other goods and services.
+
+\par Copyright
+
+This software is Copyright (C) 2011-2016 Mike McCauley. Use is subject to license
+conditions. The main licensing options available are GPL V2 or Commercial:
+
+\par Open Source Licensing GPL V2
+
+This is the appropriate option if you want to share the source code of your
+application with everyone you distribute it to, and you also want to give them
+the right to share who uses it. If you wish to use this software under Open
+Source Licensing, you must contribute all your source code to the open source
+community in accordance with the GPL Version 2 when your application is
+distributed. See https://www.gnu.org/licenses/gpl-2.0.html
+
+\par Commercial Licensing
+
+This is the appropriate option if you are creating proprietary applications
+and you are not prepared to distribute and share the source code of your
+application. Purchase commercial licenses at http://airspayce.binpress.com
+
+\par Revision History
+\version 1.1 2014-04-14<br>
+             Initial public release
+\version 1.2 2014-04-23<br>
+             Fixed various typos. <br>
+             Added links to compatible Anarduino products.<br>
+             Added RHNRFSPIDriver, RH_NRF24 classes to support Nordic NRF24 based radios.
+\version 1.3 2014-04-28<br>
+             Various documentation fixups.<br>
+             RHDatagram::setThisAddress() did not set the local copy of thisAddress. Reported by Steve Childress.<br>
+             Fixed a problem on Teensy with RF22 and RF69, where the interrupt pin needs to be set for input, <br>
+             else pin interrupt doesn't work properly. Reported by Steve Childress and patched by 
+             Adrien van den Bossche. Thanks.<br>
+             Fixed a problem that prevented RF22 honouring setPromiscuous(true). Reported by Steve Childress.<br>
+             Updated documentation to clarify some issues to do with maximum message lengths 
+             reported by Steve Childress.<br>
+             Added support for yield() on systems that support it (currently Arduino 1.5.5 and later)
+             so that spin-loops can suport multitasking. Suggested by Steve Childress.<br>
+             Added RH_RF22::setGpioReversed() so the reversal it can be configured at run-time after
+             radio initialisation. It must now be called _after_ init(). Suggested by Steve Childress.<br>
+\version 1.4 2014-04-29<br>
+             Fixed further problems with Teensy compatibility for RH_RF22. Tested on Teensy 3.1.
+             The example/rf22_* examples now run out of the box with the wiring connections as documented for Teensy
+             in RH_RF22.<br>
+             Added YIELDs to spin-loops in RHRouter, RHMesh and RHReliableDatagram, RH_NRF24.<br>
+             Tested RH_Serial examples with Teensy 3.1: they now run out of the box.<br>
+             Tested RH_ASK examples with Teensy 3.1: they now run out of the box.<br>
+             Reduced default SPI speed for NRF24 from 8MHz to 1MHz on Teensy, to improve reliability when
+             poor wiring is in use.<br>
+             on some devices such as Teensy.<br>
+             Tested RH_NRF24 examples with Teensy 3.1: they now run out of the box.<br>
+\version 1.5 2014-04-29<br>
+             Added support for Nordic Semiconductor nRF905 transceiver with RH_NRF905 driver. Also
+             added examples for nRF905 and tested on Teensy 3.1
+\version 1.6 2014-04-30<br>
+             NRF905 examples were missing
+\version 1.7 2014-05-03<br>
+             Added support for Arduino Due. Tested with RH_NRF905, RH_Serial, RH_ASK.
+             IMPORTANT CHANGE to interrupt pins on Arduino with RH_RF22 and RH_RF69 constructors:
+             previously, you had to specify the interrupt _number_ not the interrupt _pin_. Arduinos and Uno32
+             are now consistent with all other platforms: you must specify the interrupt pin number. Default
+             changed to pin 2 (a common choice with RF22 shields).
+             Removed examples/maple/maple_rf22_reliable_datagram_client and 
+             examples/maple/maple_rf22_reliable_datagram_client since the rf22 examples now work out
+             of the box with Flymaple.
+             Removed examples/uno32/uno32_rf22_reliable_datagram_client and 
+             examples/uno32/uno32_rf22_reliable_datagram_client since the rf22 examples now work out
+             of the box with ChipKit Uno32.
+\version 1.8 2014-05-08 <br>
+             Added support for YIELD in Teensy 2 and 3, suggested by Steve Childress.<br>
+             Documentation updates. Clarify use of headers and Flags<br>
+             Fixed misalignment in RH_RF69 between ModemConfigChoice definitions and the implemented choices
+             which meant you didnt get the choice you thought and GFSK_Rb55555Fd50 hung the transmitter.<br>
+             Preliminary work on Linux simulator.
+\version 1.9 2014-05-14 <br>
+             Added support for using Timer 2 instead of Timer 1 on Arduino in RH_ASK when
+             RH_ASK_ARDUINO_USE_TIMER2 is defined. With the kind assistance of
+             Luc Small. Thanks!<br>
+             Updated comments in RHReliableDatagram concerning servers, retries, timeouts and delays.
+             Fixed an error in RHReliableDatagram where recvfrom return value was not checked.
+             Reported by Steve Childress.<br>
+             Added Linux simulator support so simple RadioHead sketches can be compiled and run on Linux.<br>
+             Added RH_TCP driver to permit message passing between simulated sketches on Linux.<br>
+             Added example simulator sketches.<br>
+             Added tools/etherSimulator.pl, a simulator of the 'Luminiferous Ether' that passes
+             messages between simulated sketches and can simulate random message loss etc.<br>
+             Fixed a number of typos and improved some documentation.<br>
+\version 1.10 2014-05-15 <br>
+             Added support for RFM73 modules to RH_NRF24. These 2 radios are very similar, and can interoperate
+             with each other. Added new RH_NRF24::TransmitPower enums for the RFM73, which has a different 
+             range of available powers<br>
+             reduced the default SPI bus speed for RH_NRF24 to 1MHz, since so many modules and CPU have problems
+             with 8MHz.<br>
+\version 1.11 2014-05-18<br>
+             Testing RH_RF22 with RFM23BP and 3.3V Teensy 3.1 and 5V Arduinos. 
+             Updated documentation with respect to GPIO and antenna
+             control pins for RFM23. Updated documentation with respect to transmitter power control for RFM23<br>
+             Fixed a problem with RH_RF22 driver, where GPIO TX and RX pins were not configured during
+             initialisation, causing poor transmit power and sensitivity on those RF22/RF23 devices where GPIO controls
+             the antenna selection pins.
+\version 1.12 2014-05-20<br>
+             Testing with RF69HW and the RH_RF69 driver. Works well with the Anarduino MiniWireless -CW and -HW 
+             boards http://www.anarduino.com/miniwireless/ including
+             the marvellous high powered MinWireless-HW (with 20dBm output for excellent range).<br>
+             Clarified documentation of RH_RF69::setTxPower values for different models of RF69.<br>
+             Added RHReliableDatagram::resetRetransmissions().<br>
+             Retransmission count precision increased to uin32_t.<br>
+             Added data about actual power measurements from RFM22 module.<br>
+\version 1.13 2014-05-23<br>
+             setHeaderFlags(flags) changed to setHeaderFlags(set, clear), enabling any flags to be
+             individually set and cleared by either RadioHead or application code. Requested by Steve Childress.<br>
+             Fixed power output setting for boost power on RF69HW for 18, 19 and 20dBm.<br>
+             Added data about actual power measurements from RFM69W and RFM69HW modules.<br>
+\version 1.14 2014-05-26<br>
+             RH_RF69::init() now always sets the PA boost back to the default settings, else can get invalid
+             PA power modes after uploading new sketches without a power cycle. Reported by Bryan.<br>
+             Added new macros RH_VERSION_MAJOR RH_VERSION_MINOR, with automatic maintenance in Makefile.<br>
+             Improvements to RH_TCP: constructor now honours the server argument in the form "servername:port".<br>
+             Added YIELD to RHReliableDatagram::recvfromAckTimeout. Requested by Steve Childress.<br>
+             Fixed a problem with RH_RF22 reliable datagram acknowledgements that was introduced in version 1.13.
+             Reported by Steve Childress.<br>
+\version 1.15 2014-05-27<br>
+             Fixed a problem with the RadioHead .zip link.
+\version 1.16 2014-05-30 <br>
+             Fixed RH_RF22 so that lastRssi() returns the signal strength in dBm. Suggested by Steve Childress.<br>
+             Added support for getLastPreambleTime() to RH_RF69. Requested by Steve Childress.<br>
+             RH_NRF24::init() now checks if there is a device connected and responding, else init() will fail.
+             Suggested by Steve Brown.<br>
+             RHSoftwareSPI now initialises default values for SPI pins MOSI = 12, MISO = 11 and SCK = 13.<br>
+             Fixed some problems that prevented RH_NRF24 working with mixed software and hardware SPI 
+             on different devices: a race condition
+             due to slow SPI transfers and fast acknowledgement.<br>
+\version 1.17 2014-06-02 <br>
+             Fixed a debug typo in RHReliableDatagram that was introduced in 1.16.<br>
+             RH_NRF24 now sets default power, data rate and channel in init(), in case another
+             app has previously set different values without powerdown.<br>
+             Caution: there are still problems with RH_NRF24 and Software SPI. Do not use.<br>
+\version 1.18 2014-06-02<br>
+             Improvements to performance of RH_NRF24 statusRead, allowing RH_NRF24 and Software SPI
+             to operate on slow devices like Arduino Uno.<br>
+\version 1.19 2014-06-19<br>
+             Added examples ask_transmitter.pde and ask_receiver.pde.<br>
+             Fixed an error in the RH_RF22 doc for connection of Teensy to RF22.<br>
+             Improved documentation of start symbol bit patterns in RH_ASK.cpp
+\version 1.20 2014-06-24<br>
+             Fixed a problem with compiling on platforms such as ATTiny where SS is not defined.<br>
+             Added YIELD to RHMesh::recvfromAckTimeout().<br>
+\version 1.21 2014-06-24<br>
+             Fixed an issue in RH_Serial where characters might be lost with back-to-back frames.
+             Suggested by Steve Childress.<br>
+             Brought previous RHutil/crc16.h code into mainline RHCRC.cpp to prevent name collisions
+             with other similarly named code in other libraries. Suggested by Steve Childress.<br>
+             Fix SPI bus speed errors on 8MHz Arduinos.
+\version 1.22 2014-07-01<br>
+             Update RH_ASK documentation for common wiring connections.<br>
+             Testing RH_ASK with HopeRF RFM83C/RFM85 courtesy Anarduino http://www.anarduino.com/<br>
+             Testing RH_NRF24 with Itead Studio IBoard Pro http://imall.iteadstudio.com/iboard-pro.html
+             using both hardware SPI on the ITDB02 Parallel LCD Module Interface pins and software SPI
+             on the nRF24L01+ Module Interface pins. Documented wiring required.<br>
+             Added support for AVR 1284 and 1284p, contributed by Peter Scargill.
+             Added support for Semtech SX1276/77/78 and HopeRF RFM95/96/97/98 and other similar LoRa capable radios
+             in LoRa mode only. Tested with the excellent MiniWirelessLoRa from 
+             Anarduino http://www.anarduino.com/miniwireless<br>
+\version 1.23 2014-07-03<br>
+             Changed the default modulation for RH_RF69 to GFSK_Rb250Fd250, since the previous default
+             was not very reliable.<br>
+             Documented RH_RF95 range tests.<br>
+             Improvements to RH_RF22 RSSI readings so that lastRssi correctly returns the last message in dBm.<br>
+\version 1.24 2014-07-18
+             Added support for building RadioHead for STM32F4 Discovery boards, using the native STM Firmware libraries,
+             in order to support Codec2WalkieTalkie (http://www.airspayce.com/mikem/Codec2WalkieTalkie)
+             and other projects. See STM32ArduinoCompat.<br>
+             Default modulation for RH_RF95 was incorrectly set to a very slow Bw125Cr48Sf4096
+\version 1.25 2014-07-25
+             The available() function will longer terminate any current transmission, and force receive mode. 
+             Now, if there is no unprocessed incoming message and an outgoing message is currently being transmitted, 
+             available() will return false.<br>
+             RHRouter::sendtoWait(uint8_t*, uint8_t, uint8_t, uint8_t) renamed to sendtoFromSourceWait due to conflicts
+             with new sendtoWait() with optional flags.<br>
+             RHMEsh and RHRouter already supported end-to-end application layer flags, but RHMesh::sendtoWait() 
+             and RHRouter::sendToWait have now been extended to expose a way to send optional application layer flags.
+\version 1.26 2014-08-12
+             Fixed a Teensy 2.0 compile problem due yield() not available on Teensy < 3.0. <br>
+             Adjusted the algorithm of RH_RF69::temperatureRead() to more closely reflect reality.<br>
+             Added functions to RHGenericDriver to get driver packet statistics: rxBad(), rxGood(), txGood().<br>
+             Added RH_RF69::printRegisters().<br>
+             RH_RF95::printRegisters() was incorrectly printing the register index instead of the address.
+             Reported by Phang Moh Lim.<br>
+             RH_RF95, added definitions for some more registers that are usable in LoRa mode.<br>
+             RH_RF95::setTxPower now uses RH_RF95_PA_DAC_ENABLE to achieve 21, 22 and 23dBm.<br>
+             RH_RF95, updated power output measurements.<br>
+             Testing RH_RF69 on Teensy 3.1 with RF69 on PJRC breakout board. OK.<br>
+             Improvements so RadioHead will build under Arduino where SPI is not supported, such as 
+             ATTiny.<br>
+             Improvements so RadioHead will build for ATTiny using Arduino IDE and tinycore arduino-tiny-0100-0018.zip.<br>
+             Testing RH_ASK on ATTiny85. Reduced RAM footprint. 
+             Added helpful documentation. Caution: RAM memory is *very* tight on this platform.<br>
+             RH_RF22 and RH_RF69, added setIdleMode() function to allow the idle mode radio operating state
+             to be controlled for lower idle power consumption at the expense of slower transitions to TX and RX.<br>
+\version 1.27 2014-08-13
+             All RH_RF69 modulation schemes now have data whitening enabled by default.<br>
+             Tested and added a number of OOK modulation schemes to RH_RF69 Modem config table.<br>
+             Minor improvements to a number of the faster RH_RF69 modulation schemes, but some slower ones
+             are still not working correctly.<br>
+\version 1.28 2014-08-20
+             Added new RH_RF24 driver to support Si446x, RF24/26/26, RFM24/26/27 family of transceivers.
+             Tested with the excellent
+             Anarduino Mini and RFM24W and RFM26W with the generous assistance of the good people at 
+             Anarduino http://www.anarduino.com.
+\version 1.29 2014-08-21
+             Fixed a compile error in RH_RF24 introduced at the last minute in hte previous release.<br>
+             Improvements to RH_RF69 modulation schemes: now include the AFCBW in teh ModemConfig.<br>
+             ModemConfig RH_RF69::FSK_Rb2Fd5 and RH_RF69::GFSK_Rb2Fd5 are now working.<br> 
+\version 1.30 2014-08-25
+             Fixed some compile problems with ATtiny84 on Arduino 1.5.5 reported by Glen Cook.<br>
+\version 1.31 2014-08-27
+             Changed RH_RF69 FSK and GFSK modulations from Rb2_4Fd2_4 to Rb2_4Fd4_8 and FSK_Rb4_8Fd4_8 to FSK_Rb4_8Fd9_6
+             since the previous ones were unreliable (they had modulation indexes of 1).<br>
+\version 1.32 2014-08-28
+             Testing with RedBearLab Blend board http://redbearlab.com/blend/. OK.<br>
+             Changed more RH_RF69 FSK and GFSK slowish modulations to have modulation index of 2 instead of 1. 
+             This required chnaging the symbolic names.<br>
+\version 1.33 2014-09-01
+             Added support for sleep mode in RHGeneric driver, with new mode 
+             RHModeSleep and new virtual function sleep().<br>
+             Added support for sleep to RH_RF69, RH_RF22, RH_NRF24, RH_RF24, RH_RF95 drivers.<br>
+\version 1.34 2014-09-19
+             Fixed compile errors in example rf22_router_test.<br>
+             Fixed a problem with RH_NRF24::setNetworkAddress, also improvements to RH_NRF24 register printing.
+             Patched by Yveaux.<br>
+             Improvements to RH_NRF24 initialisation for version 2.0 silicon.<br>
+             Fixed problem with ambigiguous print call in RH_RFM69 when compiling for Codec2.<br>
+             Fixed a problem with RH_NRF24 on RFM73 where the LNA gain was not set properly, reducing the sensitivity
+             of the receiver.
+\version 1.35 2014-09-19
+             Fixed a problem with interrupt setup on RH_RF95 with Teensy3.1. Reported by AD.<br>
+\version 1.36 2014-09-22
+             Improvements to interrupt pin assignments for __AVR_ATmega1284__ and__AVR_ATmega1284P__, provided by
+             Peter Scargill.<br>
+             Work around a bug in Arduino 1.0.6 where digitalPinToInterrupt is defined but NOT_AN_INTERRUPT is not.<br>
+ \version 1.37 2014-10-19
+             Updated doc for connecting RH_NRF24 to Arduino Mega.<br>
+             Changes to RHGenericDriver::setHeaderFlags(), so that the default for the clear argument
+             is now RH_FLAGS_APPLICATION_SPECIFIC, which is less surprising to users.
+             Testing with the excellent MoteinoMEGA from LowPowerLab 
+             https://lowpowerlab.com/shop/moteinomega with on-board RFM69W.
+ \version 1.38 2014-12-29
+             Fixed compile warning on some platforms where RH_RF24::send and RH_RF24::writeTxFifo 
+             did not return a value.<br>
+             Fixed some more compiler warnings in RH_RF24 on some platforms.<br>
+             Refactored printRegisters for some radios. Printing to Serial
+             is now controlled by the definition of RH_HAVE_SERIAL.<br>
+             Added partial support for ARM M4 w/CMSIS with STM's Hardware Abstraction lib for 
+             Steve Childress.<br>
+ \version 1.39 2014-12-30
+             Fix some compiler warnings under IAR.<br>
+             RH_HAVE_SERIAL and Serial.print calls removed for ATTiny platforms.<br>
+ \version 1.40 2015-03-09
+             Added notice about availability on PlatformIO, thanks to Ivan Kravets.<br>
+             Fixed a problem with RH_NRF24 where short packet lengths would occasionally not be trasmitted
+             due to a race condition with RH_NRF24_TX_DS. Reported by Mark Fox.<br>
+ \version 1.41 2015-03-29
+             RH_RF22, RH_RF24, RH_RF69 and RH_RF95 improved to allow driver.init() to be called multiple
+             times without reallocating a new interrupt, allowing the driver to be reinitialised
+             after sleeping or powering down.
+ \version 1.42 2015-05-17
+             Added support for RH_NRF24 driver on Raspberry Pi, using BCM2835
+             library for GPIO pin IO. Contributed by Mike Poublon.<br>
+             Tested RH_NRF24 module with NRF24L01+PA+LNA SMA Antenna Wireless Transceiver modules
+             similar to: http://www.elecfreaks.com/wiki/index.php?title=2.4G_Wireless_nRF24L01p_with_PA_and_LNA
+             works with no software changes. Measured max power output 18dBm.<br>
+ \version 1.43 2015-08-02
+             Added RH_NRF51 driver to support Nordic nRF51 family processor with 2.4GHz radio such 
+             as nRF51822, to be built on Arduino 1.6.4 and later. Tested with RedBearLabs nRF51822 board
+             and BLE Nano kit<br>
+ \version 1.44 2015-08-08
+             Fixed errors with compiling on some platforms without serial, such as ATTiny. 
+             Reported by Friedrich Müller.<br>
+ \version 1.45 2015-08-13
+             Added support for using RH_Serial on Linux and OSX (new class RHutil/HardwareSerial
+             encapsulates serial ports on those platforms). Example examples/serial upgraded
+             to build and run on Linux and OSX using the tools/simBuild builder.
+             RHMesh, RHRouter and RHReliableDatagram updated so they can use RH_Serial without
+             polling loops on Linux and OSX for CPU efficiency.<br>
+ \version 1.46 2015-08-14
+             Amplified some doc concerning Linux and OSX RH_Serial. Added support for 230400
+             baud rate in HardwareSerial.<br>
+             Added sample sketches nrf51_audio_tx and nrf51_audio_rx which show how to
+             build an audio TX/RX pair with RedBear nRF51822 boards and a SparkFun MCP4725 DAC board.
+             Uses the built-in ADC of the nRF51822 to sample audio at 5kHz and transmit packets
+             to the receiver which plays them via the DAC.<br>
+\version 1.47 2015-09-18
+             Removed top level Makefile from distribution: its only used by the developer and 
+             its presence confuses some people.<br>
+             Fixed a problem with RHReliableDatagram with some versions of Raspberry Pi random() that causes 
+             problems: random(min, max) sometimes exceeds its max limit.
+\version 1.48 2015-09-30
+             Added support for Arduino Zero. Tested on Arduino Zero Pro.
+\version 1.49 2015-10-01
+             Fixed problems that prevented interrupts working correctly on Arduino Zero and Due.
+             Builds and runs with 1.6.5 (with 'Arduino SAMD Boards' for Zero version 1.6.1) from arduino.cc.
+             Arduino version 1.7.7 from arduino.org is not currently supported.
+\version 1.50 2015-10-25
+             Verified correct building and operation with Arduino 1.7.7 from arduino.org.
+             Caution: You must burn the bootloader from 1.7.7 to the Arduino Zero before it will 
+             work with Arduino 1.7.7 from arduino.org. Conversely, you must burn the bootloader from 1.6.5 
+             to the Arduino Zero before it will 
+             work with Arduino 1.6.5 from arduino.cc. Sigh.
+             Fixed a problem with RH_NRF905 that prevented the power and frequency ranges being set
+             properly. Reported by Alan Webber.
+\version 1.51 2015-12-11
+             Changes to RH_RF6::setTxPower() to be compatible with SX1276/77/78/79 modules that
+             use RFO transmitter pins instead of PA_BOOST, such as the excellent
+             Modtronix inAir4 http://modtronix.com/inair4.html 
+             and inAir9 modules http://modtronix.com/inair9.html. With the kind assistance of 
+             David from Modtronix.
+\version 1.52 2015-12-17
+             Added RH_MRF89 module to suport Microchip MRF89XA and compatible transceivers.
+             and modules.<br>
+\version 1.53 2016-01-02
+             Added RH_CC110 module to support Texas Instruments CC110L and compatible transceivers and modules.<br>
+\version 1.54 2016-01-29
+             Added support for ESP8266 processor on Arduino IDE. Examples serial_reliable_datagram_* are shown to work. 
+             CAUTION: SPI not supported yet. Timers used by RH_ASK are not tested. 
+             The GHz radio included in the ESP8266 is not yet supported. 
+\version 1.55 2016-02-12
+             Added macros for htons() and friends to RadioHead.h.
+             Added example sketch serial_gateway.pde. Acts as a transparent gateway between RH_RF22 and RH_Serial, 
+             and with minor mods acts as a universal gateway between any 2 RadioHead driver networks.
+             Initial work on supporting STM32 F2 on Particle Photon: new platform type defined.
+             Fixed many warnings exposed by test building for Photon.
+             Particle Photon tested support for RH_Serial, RH_ASK, SPI, RH_CC110 etc.
+             Added notes on how to build RadioHead sketches for Photon.
+\version 1.56 2016-02-18 
+             Implemented timers for RH_ASK on ESP8266, added some doc on IO pin selection.
+\version 1.57 2016-02-23
+             Fixed an issue reported by S3B, where RH_RF22 would sometimes not clear the rxbufvalid flag.
+\version 1.58 2-16-04-04
+             Tested RH_RF69 with Arduino Due. OK. Updated doc.<br>
+             Added support for all ChipKIT Core supported boards 
+             http://chipkit.net/wiki/index.php?title=ChipKIT_core
+             Tested on ChipKIT Uno32.<br>
+             Digilent Uno32 under the old MPIDE is no longer formally 
+             supported but may continue to work for some time.<br>
+\version 1.59 2016-04-12
+             Testing with the excellent Rocket Scream Mini Ultra Pro with the RFM95W and RFM69HCW modules from
+             http://www.rocketscream.com/blog/product/mini-ultra-pro-with-radio/  (915MHz versions). Updated
+             documentation with hints to suit. Caution: requires Arduino 1.6.8 and Arduino SAMD Boards 1.6.5.
+             See also http://www.rocketscream.com/blog/2016/03/10/radio-range-test-with-rfm69hcw/
+             for the vendors tests and range with the RFM69HCW version. They also have an RF95 version equipped with
+             TCXO temperature controllled oscillator for extra frequency stability and support of very slow and
+             long range protocols.
+             These boards are highly recommended. They also include battery charging support.
+\version 1.60 2016-06-25
+             Tested with the excellent talk2 Whisper Node boards 
+            (https://talk2.wisen.com.au/ and https://bitbucket.org/talk2/), 
+             an Arduino Nano compatible board, which include an on-board RF69 radio, external antenna, 
+             run on 2xAA batteries and support low power operations. RF69 examples work without modification.
+             Added support for ESP8266 SPI, provided by David Skinner.
+\version 1.61 2016-07-07
+             Patch to RH_ASK.cpp for ESP8266, to prevent crashes in interrupt handlers. Patch from Alexander Mamchits.
+\version 1.62 2016-08-17
+             Fixed a problem in RH_ASK where _rxInverted was not properly initialised. Reported by "gno.sun.sop".
+             Added support for  waitCAD() and isChannelActive() and setCADTimeout() to RHGeneric.
+             Implementation of RH_RF95::isChannelActive() allows the RF95 module to support
+             Channel Activity Detection (CAD). Based on code contributed by Bent Guldbjerg Christensen.
+             Implmentations of isChannelActive() plus documentation for other radio modules wil be welcomed.
+\version 1.63 2016-10-20
+             Testing with Adafruit Feather 32u4 with RFM69HCW. Updated documentation to reflect.<br>
+\version 1.64 2016-12-10
+             RHReliableDatagram now initialises _seenids. Fix from Ben Lim.<br>
+             In RH_NRF51, added get_temperature().<br>
+             In RH_NRF51, added support for AES packet encryption, which required a slight change 
+             to the on-air message format.<br>
+\version 1.65 2017-01-11
+             Fixed a race condition with RH_NRF51 that prevented ACKs being reliably received.<br>
+             Removed code in RH_NRF51 that enabled the DC-DC converter. This seems not to be a necessary condition
+             for the radio to work and is now left to the application if that is required.<br>
+             Proven interoperation between nRF51822 and nRF52832.<br>
+             Modification and testing of RH_NRF51 so it works with nRF52 family processors,
+             such Sparkfun nRF52832 breakout board, with Arduino 1.6.13 and
+             Sparkfun nRF52 boards manager 0.2.3 using the procedures outlined in
+             https://learn.sparkfun.com/tutorials/nrf52832-breakout-board-hookup-guide<br>
+             Caution, the Sparkfun development system for Arduino is still immature. We had to 
+             rebuild the nrfutil program since the supplied one was not suitable for 
+             the Linux host we were developing on. See https://forum.sparkfun.com/viewtopic.php?f=32&t=45071
+             Also, after downloading a sketch in the nRF52832, the program does not start executing cleanly: 
+             you have to reset the processor again by pressing the reset button. 
+             This appears to be a problem with nrfutil, rather than a bug in RadioHead.
+\version 1.66 2017-01-15
+             Fixed some errors in (unused) register definitions in RH_RF95.h.<br>
+             Fixed a problem that caused compilation errors in RH_NRF51 if the appropriate board 
+             support was not installed.
+\version 1.67 2017-01-24
+             Added RH_RF95::frequencyError() to return the estimated centre frequency offset in Hz 
+             of the last received message
+\version 1.68 2017-01-25
+             Fixed arithmetic error in RH_RF95::frequencyError() for some platforms.
+\version 1.69 2017-02-02
+             Added RH_RF95::lastSNR() and improved lastRssi() calculations per the manual.
+\version 1.70 2017-02-03
+             Added link to Binpress commercial license purchasing.
+\version 1.71 2017-02-07
+             Improved support for STM32. Patch from Bent Guldbjerg Christensen.
+\version 1.72 2017-03-02
+             In RH_RF24, fixed a problem where some important properties were not set by the ModemConfig.
+             Added properties 2007, 2008, 2009. Also properties 200a was not being set in the chip.
+             Reported by Shannon Bailey and Alan Adamson.
+             Fixed corresponding convert.pl and added it to the distribution.
+\version 1.73 2017-03-04
+             Significant changes to RH_RF24 and its API. It is no longer possible to change the modulation scheme
+             programatically: it proved impossible to cater for all the possible crystal frequencies,
+             base frequency and modulation schemes. Instead you can use one of a small set of supplied radio
+             configuration header files, or generate your own with Silicon Labs WDS application. Changing
+             modulation scheme required editing RH_RF24.cpp to specify the appropriate header and recompiling.
+             convert.pl is now redundant and removed from the distribution.
+\version 1.74 2017-03-08
+             Changed RHReliableDatagram so it would not ACK messages heard addressed to other nodes
+             in promiscuous mode.<br>
+             Added RH_RF24::deviceType() to return the integer value of the connected device.<br>
+             Added documentation about how to connect RFM69 to an ESP8266. Tested OK.<br>
+             RH_RF24 was not correctly changing state in sleep() and setModeIdle().<br>
+             Added example rf24_lowpower_client.pde showing how to put an arduino and radio into a low power
+             mode between transmissions to save battery power.<br>
+             Improvements to RH_RF69::setTxPower so it now takes an optional ishighpowermodule
+             flag to indicate if the connected module is a high power RFM69HW, and so set the power level
+             correctly. Based on code contributed by bob.
+\version 1.75 2017-06-22
+             Fixed broken compiler issues with RH_RF95::frequencyError() reported by Steve Rogerson.<br>
+             Testing with the very excellent Rocket Scream boards equipped with RF95 TCXO modules. The
+             temperature controlled oscillator stabilises the chip enough to be able to use even the slowest
+             protocol Bw125Cr48Sf4096. Caution, the TCXO model radios are not low power when in sleep (consuming
+             about ~600 uA, reported by Phang Moh Lim).<br>
+             Added support for EBYTE E32-TTL-1W and family serial radio transceivers. These RF95 LoRa based radios
+             can deliver reliable messages at up to 7km measured.
+\version 1.76 2017-06-23
+             Fixed a problem with RH_RF95 hanging on transmit under some mysterious circumstances.
+             Reported by several people at  https://forum.pjrc.com/threads/41878-Probable-race-condition-in-Radiohead-library?p=146601#post146601 <br>
+             Increased the size of rssi variables to 16 bits to permit RSSI less than -128 as reported by RF95.
+\version 1.77 2017-06-25
+             Fixed a compilation error with lastRssi().<br>
+\version 1.78 2017-07-19
+             Fixed a number of unused variable warnings from g++.<br>
+             Added new module RHEncryptedDriver and examples, contributed by Philippe Rochat, which
+             adds encryption and decryption to any RadioHead transport driver, using any encryption cipher
+             supported by ArduinoLibs Cryptographic Library http://rweather.github.io/arduinolibs/crypto.html
+             Includes several examples.<br>
+\version 1.79 2017-07-25
+             Added documentation about 'Passing Sensor Data Between RadioHead nodes'.<br>
+             Changes to RH_CC110 driver to calculate RSSI in dBm, based on a patch from Jurie Pieterse.<br>
+             Added missing passthroughmethoids to RHEncryptedDriver, allowing it to be used with RHDatagram,
+             RHReliableDatagram etc. Tested with RH_Serial. Added examples
+\version 1.80 2017-10-04
+             Testing with the very fine Talk2 Whisper Node LoRa boards https://wisen.com.au/store/products/whisper-node-lora
+             an Arduino compatible board, which include an on-board RFM95/96 LoRa Radio (Semtech SX1276), external antenna, 
+             run on 2xAAA batteries and support low power operations. RF95 examples work without modification.
+             Use Arduino Board Manager to install the Talk2 code support. Upload the code with an FTDI adapter set to 5V.<br>
+             Added support for SPI transactions in development environments that support it with SPI_HAS_TRANSACTION.
+             Tested on ESP32 with RFM-22 and Teensy 3.1 with RF69
+             Added support for ESP32, tested with RFM-22 connected by SPI.<br>
+\version 1.81 2017-11-15
+             RH_CC110, moved setPaTable() from protected to public.<br>
+             RH_RF95 modem config Bw125Cr48Sf4096 altered to enable slow daat rate in register 26
+             as suggested by Dieter Kneffel.
+             Added support for nRF52 compatible Arm chips such as as Adafruit BLE Feather board
+             https://www.adafruit.com/product/3406, with a patch from Mike Bell.<br>
+             Fixed a problem where rev 1.80 broke Adafruit M0 LoRa support by declaring 
+             bitOrder variable always as a unsigned char. Reported by Guilherme Jardim.<br>
+             In RH_RF95, all modes now have AGC enabled, as suggested by Dieter Kneffel.<br>
+\version 1.82 2018-01-07
+             Added guard code to RH_NRF24::waitPacketSent() so that if the transmit never completes for some
+             reason, the code will eventually return with FALSE.
+             Added the low-datarate-optimization bit to config for RH_RF95::Bw125Cr48Sf4096.
+             Fix from Jurie Pieterse to ensure RH_CC110::sleep always enters sleep mode.
+             Update ESP32 support to include ASK timers. RH_ASK module is now working on ESP32.
+\version 1.83 2018-02-12
+             Testing adafruit M0 Feather with E32. Updated RH_E32 documentation to show suggested connections
+             and contructor initialisation.<br>
+             Fixed a problem with RHEncryptedDriver that could cause a crash on some platforms when used
+             with RHReliableDatagram. Reported by Joachim Baumann.<br>
+	     Improvments to doxygen doc layout in RadioHead.h
+
+\author  Mike McCauley. DO NOT CONTACT THE AUTHOR DIRECTLY. USE THE GOOGLE LIST GIVEN ABOVE
+*/
 
 /*! \page packingdata 
 \par Passing Sensor Data Between RadioHead nodes
@@ -831,7 +853,7 @@ amongst beginners, is that there is no *best* way to do it. The best
 solution for your project may depend on the range of processors and
 data that you have to deal with. Also, it gets more difficult if you
 need to send several numbers in one packet, and/or deal with floating
-point numbers.
+point numbers and/or different types of processors.
 
 The principal cause of difficulty is that different microprocessors of
 the kind that run RadioHead may have different ways of representing
@@ -924,21 +946,22 @@ transmitter and receiver have different endianness: the integers you
 receive will not be the same as the ones you sent (actually they are,
 but with the internal bytes swapped around, so they probably wont make
 sense to you). Endianness is not a problem if *every* data item you
-send is a just single byte (uint8_t or int8_t or char).
+send is a just single byte (uint8_t or int8_t or char), or if the
+transmitter and receiver have the same endianness.
 
 So you should only adopt this technique if:
 - You only send data items of a single byte each, or
 - You are absolutely sure (now and forever into the future) that you
-will only ever use the same processor in the transmitter and receiver.
+will only ever use the same processor endianness in the transmitter and receiver.
 
 \par Network Order Binary
 
-One solution to the issue of endianness in your processors to to
+One solution to the issue of endianness in your processors is to
 always convert your data from the processor's native byte order to
 'network byte order' before transmission and then convert it back to
-the receiver's native byte order. You do this with the htons (host to
-network short) macro and friends. These functions may be a no-op on
-big-endian processors.
+the receiver's native byte order on receoption. You do this with the
+htons (host to network short) macro and friends. These functions may
+be a no-op on big-endian processors.
 
 With this technique you convert every multi-byte number to and from
 network byte order (note that in most Arduino processors an integer is
@@ -1061,7 +1084,7 @@ these examples and explanations and extend them to suit your needs.
 
 // Official version numbers are maintained automatically by Makefile:
 #define RH_VERSION_MAJOR 1
-#define RH_VERSION_MINOR 82
+#define RH_VERSION_MINOR 83
 
 // Symbolic names for currently supported platform types
 #define RH_PLATFORM_ARDUINO          1
@@ -1285,7 +1308,7 @@ these examples and explanations and extend them to suit your needs.
 #if (RH_PLATFORM == RH_PLATFORM_ARDUINO && ARDUINO >= 155 && !defined(RH_PLATFORM_ATTINY)) || (TEENSYDUINO && defined(__MK20DX128__))
  #define YIELD yield();
 #elif (RH_PLATFORM == RH_PLATFORM_ESP8266)
-// ESP8266 also hash it
+// ESP8266 also has it
  #define YIELD yield();
 #else
  #define YIELD

--- a/RadioHead.h
+++ b/RadioHead.h
@@ -1,7 +1,7 @@
 // RadioHead.h
 // Author: Mike McCauley (mikem@airspayce.com) DO NOT CONTACT THE AUTHOR DIRECTLY
 // Copyright (C) 2014 Mike McCauley
-// $Id: RadioHead.h,v 1.70 2018/02/11 23:57:18 mikem Exp mikem $
+// $Id: RadioHead.h,v 1.71 2018/05/06 22:23:51 mikem Exp mikem $
 
 /*! \mainpage RadioHead Packet Radio library for embedded microprocessors
 
@@ -10,7 +10,7 @@ It provides a complete object-oriented library for sending and receiving packeti
 via a variety of common data radios and other transports on a range of embedded microprocessors.
 
 The version of the package that this documentation refers to can be downloaded 
-from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.83.zip
+from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.84.zip
 You can find the latest version of the documentation at http://www.airspayce.com/mikem/arduino/RadioHead
 
 You can also find online help and discussion at 
@@ -62,7 +62,7 @@ The following Drivers are provided:
 Works with Hope-RF
 RF22B and RF23B based transceivers, and compatible chips and modules, 
 including the RFM22B transceiver module such as 
-this bare module: http://www.sparkfun.com/products/10153
+hthis bare module: http://www.sparkfun.com/products/10153
 and this shield: http://www.sparkfun.com/products/11018 
 and this board: http://www.anarduino.com/miniwireless
 and RF23BP modules such as: http://www.anarduino.com/details.jsp?pid=130
@@ -183,6 +183,12 @@ Including Diecimila, Uno, Mega, Leonardo, Yun, Due, Zero etc. http://arduino.cc/
  - Various Talk2 Whisper boards eg https://wisen.com.au/store/products/whisper-node-lora.
    Use Arduino Board Manager to install the Talk2 code support. 
  - etc.
+
+- STM32 F4 Discover board, using Arduino 1.8.2 or later and
+   Roger Clarkes Arduino_STM from https://github.com/rogerclarkmelbourne/Arduino_STM32
+   Caution: with this library and board, sending text to Serial causes the board to hang in mysterious ways. 
+   Serial2 emits to PA2. The default SPI pins are SCK: PB3, MOSI PB5, MISO PB4. 
+   We tested with PB0 as slave select and PB1 as interrupt pin for various radios. RH_ASK and RH_Serial also work.
 
 - ChipKIT Core with Arduino IDE on any ChipKIT Core supported Digilent processor (tested on Uno32)
 http://chipkit.net/wiki/index.php?title=ChipKIT_core
@@ -836,6 +842,10 @@ application. Purchase commercial licenses at http://airspayce.binpress.com
              Fixed a problem with RHEncryptedDriver that could cause a crash on some platforms when used
              with RHReliableDatagram. Reported by Joachim Baumann.<br>
 	     Improvments to doxygen doc layout in RadioHead.h
+\version 1.84 2018-05-07
+             Compiles with Roger Clarkes Arduino_STM32 https://github.com/rogerclarkmelbourne/Arduino_STM32,
+	     to support STM32F103C etc, and STM32 F4 Discovery etc.<br>
+	     Tested STM32 F4 Discovery board with RH_RF22, RH_ASK and RH_Serial.
 
 \author  Mike McCauley. DO NOT CONTACT THE AUTHOR DIRECTLY. USE THE GOOGLE LIST GIVEN ABOVE
 */
@@ -870,7 +880,7 @@ your RadioHead distribution.  But your needs may be more complicated
 than that.
 
 The essence of all engineering is compromise so it will be up to you to
-decide whats best for your paricular needs. The main choices are:
+decide whats best for your particular needs. The main choices are:
 - Raw Binary
 - Network Order Binary
 - ASCII
@@ -880,7 +890,7 @@ decide whats best for your paricular needs. The main choices are:
 With this technique you just pack the raw binary numbers into the packet:
 
 \code
-// Sending a single integer
+// Sending a single 16 bit unsigned integer
 // in the transmitter:
 ...
 uint16_t data = getsomevalue();
@@ -906,7 +916,7 @@ If you need to send more than one number at a time, its best to pack
 them into a structure
 
 \code
-// Sending several integers in a structure
+// Sending several 16 bit unsigned integers in a structure
 // in a common header for your project:
 typedef struct
 {
@@ -959,7 +969,7 @@ will only ever use the same processor endianness in the transmitter and receiver
 One solution to the issue of endianness in your processors is to
 always convert your data from the processor's native byte order to
 'network byte order' before transmission and then convert it back to
-the receiver's native byte order on receoption. You do this with the
+the receiver's native byte order on reception. You do this with the
 htons (host to network short) macro and friends. These functions may
 be a no-op on big-endian processors.
 
@@ -970,7 +980,7 @@ that explicitly specify their size so we can be sure of applying the
 right conversions):
 
 \code
-// Sending a single integer
+// Sending a single 16 bit unsigned integer
 // in the transmitter:
 ...
 uint16_t data = htons(getsomevalue());
@@ -995,7 +1005,7 @@ If you need to send more than one number at a time, its best to pack
 them into a structure
 
 \code
-// Sending several integers in a structure
+// Sending several 16 bit unsigned integers in a structure
 // in a common header for your project:
 typedef struct
 {
@@ -1084,7 +1094,7 @@ these examples and explanations and extend them to suit your needs.
 
 // Official version numbers are maintained automatically by Makefile:
 #define RH_VERSION_MAJOR 1
-#define RH_VERSION_MINOR 83
+#define RH_VERSION_MINOR 84
 
 // Symbolic names for currently supported platform types
 #define RH_PLATFORM_ARDUINO          1
@@ -1159,6 +1169,11 @@ these examples and explanations and extend them to suit your needs.
   #include <SPI.h>
   #define RH_HAVE_HARDWARE_SPI
   #define RH_HAVE_SERIAL
+ #endif
+ #if defined(ARDUINO_ARCH_STM32F4)
+  // output to Serial causes hangs on STM32 F4 Discovery board
+  // There seems to be no way to output text to the USB connection
+  #define Serial Serial2
  #endif
 
 #elif (RH_PLATFORM == RH_PLATFORM_ESP8266) // ESP8266 processor on Arduino IDE

--- a/RadioHead.h
+++ b/RadioHead.h
@@ -10,7 +10,7 @@ It provides a complete object-oriented library for sending and receiving packeti
 via a variety of common data radios and other transports on a range of embedded microprocessors.
 
 The version of the package that this documentation refers to can be downloaded 
-from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.84.zip
+from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.85.zip
 You can find the latest version of the documentation at http://www.airspayce.com/mikem/arduino/RadioHead
 
 You can also find online help and discussion at 
@@ -136,7 +136,7 @@ testing of Manager classes on Linux and without need for real radios or other tr
 
 - RHEncryptedDriver
 Adds encryption and decryption to any RadioHead transport driver, using any encrpytion cipher
-supported by ArduinoLibs Cryptogrphic Library http://rweather.github.io/arduinolibs/crypto.html
+supported by ArduinoLibs Cryptographic Library http://rweather.github.io/arduinolibs/crypto.html
 
 Drivers can be used on their own to provide unaddressed, unreliable datagrams. 
 All drivers have the same identical API.
@@ -218,7 +218,7 @@ https://www.adafruit.com/product/3406
 - Adafruit Feather. These are excellent boards that are available with a variety of radios. We tested with the 
   Feather 32u4 with RFM69HCW radio, with Arduino IDE 1.6.8 and the Adafruit AVR Boards board manager version 1.6.10.
   https://www.adafruit.com/products/3076
-//
+
 - Adafruit Feather M0 boards with Arduino 1.8.1 and later, using the Arduino and Adafruit SAMD board support.
   https://learn.adafruit.com/adafruit-feather-m0-basic-proto/using-with-arduino-ide
 
@@ -275,7 +275,7 @@ http://arduino.cc/en/Guide/Libraries
 The Photon is not supported by the Arduino IDE, so it takes a little effort to set up a build environment.
 Heres what we did to enable building of RadioHead example sketches on Linux, 
 but there are other ways to skin this cat.
-Basic reference for getting stated is: http://particle-firmware.readthedocs.org/en/develop/build/
+Basic reference for getting started is: http://particle-firmware.readthedocs.org/en/develop/build/
 - Download the ARM gcc cross compiler binaries and unpack it in a suitable place:
 \code
 cd /tmp
@@ -363,7 +363,7 @@ It is not to be confused with any other similar marks covering other goods and s
 
 \par Copyright
 
-This software is Copyright (C) 2011-2016 Mike McCauley. Use is subject to license
+This software is Copyright (C) 2011-2018 Mike McCauley. Use is subject to license
 conditions. The main licensing options available are GPL V2 or Commercial:
 
 \par Open Source Licensing GPL V2
@@ -847,6 +847,16 @@ application. Purchase commercial licenses at http://airspayce.binpress.com
 	     to support STM32F103C etc, and STM32 F4 Discovery etc.<br>
 	     Tested STM32 F4 Discovery board with RH_RF22, RH_ASK and RH_Serial.
 
+\version 1.85 2018-07-09
+             RHGenericDriver methods changed to virtual, to allow overriding by RHEncrypredDriver: 
+	     lastRssi(), mode(), setMode(). Reported by Eyal Gal.<br>
+	     Fixed a problem with compiling RH_E32 on some older IDEs, contributed by Philippe Rochat.<br>
+	     Improvements to RH_RF95 to improve detection of bad packets, contributed by PiNi.<br>
+	     Fixed an error in RHEncryptedDriver that caused incorrect message lengths for messages multiples of 16 bytes 
+	     when STRICT_CONTENT_LEN is defined.<br>
+	     Fixed a bug in RHMesh which causes the creation of a route to the address which is the byte 
+	     behind the end of the route array. Reported by Pascal Gillès de Pélichy.<br>
+
 \author  Mike McCauley. DO NOT CONTACT THE AUTHOR DIRECTLY. USE THE GOOGLE LIST GIVEN ABOVE
 */
 
@@ -1094,7 +1104,7 @@ these examples and explanations and extend them to suit your needs.
 
 // Official version numbers are maintained automatically by Makefile:
 #define RH_VERSION_MAJOR 1
-#define RH_VERSION_MINOR 84
+#define RH_VERSION_MINOR 85
 
 // Symbolic names for currently supported platform types
 #define RH_PLATFORM_ARDUINO          1

--- a/RadioHead.h
+++ b/RadioHead.h
@@ -10,7 +10,7 @@ It provides a complete object-oriented library for sending and receiving packeti
 via a variety of common data radios and other transports on a range of embedded microprocessors.
 
 The version of the package that this documentation refers to can be downloaded 
-from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.85.zip
+from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.86.zip
 You can find the latest version of the documentation at http://www.airspayce.com/mikem/arduino/RadioHead
 
 You can also find online help and discussion at 
@@ -224,7 +224,7 @@ https://www.adafruit.com/product/3406
 
 - ESP32 built using Arduino IDE 1.8.1 or later using the ESP32 toolchain installed per
   https://diyprojects.io/programming-esp32-board-arduino-ide-macos-windows-linux-arm-raspberrypi-orangepi/
-  The internal 2.4GHz radio is not yet supported. Tested with RFM22 using SPI interfcace
+  The internal 2.4GHz radio is not yet supported. Tested with RFM22 using SPI interface
 
 - Raspberry Pi
   Uses BCM2835 library for GPIO http://www.airspayce.com/mikem/bcm2835/
@@ -379,7 +379,7 @@ distributed. See https://www.gnu.org/licenses/gpl-2.0.html
 
 This is the appropriate option if you are creating proprietary applications
 and you are not prepared to distribute and share the source code of your
-application. Purchase commercial licenses at http://airspayce.binpress.com
+application. To purchase a commercial license, contact info@airspayce.com
 
 \par Revision History
 \version 1.1 2014-04-14<br>
@@ -856,6 +856,8 @@ application. Purchase commercial licenses at http://airspayce.binpress.com
 	     when STRICT_CONTENT_LEN is defined.<br>
 	     Fixed a bug in RHMesh which causes the creation of a route to the address which is the byte 
 	     behind the end of the route array. Reported by Pascal Gillès de Pélichy.<br>
+\version 1.86 2018-08-28
+             Update commercial licensing, remove binpress.
 
 \author  Mike McCauley. DO NOT CONTACT THE AUTHOR DIRECTLY. USE THE GOOGLE LIST GIVEN ABOVE
 */
@@ -1104,7 +1106,7 @@ these examples and explanations and extend them to suit your needs.
 
 // Official version numbers are maintained automatically by Makefile:
 #define RH_VERSION_MAJOR 1
-#define RH_VERSION_MINOR 85
+#define RH_VERSION_MINOR 86
 
 // Symbolic names for currently supported platform types
 #define RH_PLATFORM_ARDUINO          1

--- a/RadioHead.h
+++ b/RadioHead.h
@@ -10,7 +10,7 @@
 /// via a variety of common data radios and other transports on a range of embedded microprocessors.
 ///
 /// The version of the package that this documentation refers to can be downloaded 
-/// from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.76.zip
+/// from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.77.zip
 /// You can find the latest version of the documentation at http://www.airspayce.com/mikem/arduino/RadioHead
 ///
 /// You can also find online help and discussion at 
@@ -750,6 +750,8 @@
 ///              Fixed a problem with RH_RF95 hanging on transmit under some mysterious circumstances.
 ///              Reported by several people at  https://forum.pjrc.com/threads/41878-Probable-race-condition-in-Radiohead-library?p=146601#post146601 <br>
 ///              Increased the size of rssi variables to 16 bits to permit RSSI less than -128 as reported by RF95.
+/// \version 1.77 2017-06-25
+///              Fixed a compilation error with lastRssi().<br>
 ///
 /// \author  Mike McCauley. DO NOT CONTACT THE AUTHOR DIRECTLY. USE THE MAILING LIST GIVEN ABOVE
 
@@ -758,7 +760,7 @@
 
 // Official version numbers are maintained automatically by Makefile:
 #define RH_VERSION_MAJOR 1
-#define RH_VERSION_MINOR 76
+#define RH_VERSION_MINOR 77
 
 // Symbolic names for currently supported platform types
 #define RH_PLATFORM_ARDUINO          1

--- a/RadioHead.h
+++ b/RadioHead.h
@@ -10,7 +10,7 @@
 /// via a variety of common data radios and other transports on a range of embedded microprocessors.
 ///
 /// The version of the package that this documentation refers to can be downloaded 
-/// from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.75.zip
+/// from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.76.zip
 /// You can find the latest version of the documentation at http://www.airspayce.com/mikem/arduino/RadioHead
 ///
 /// You can also find online help and discussion at 
@@ -746,6 +746,10 @@
 ///              about ~600 uA, reported by Phang Moh Lim).<br>
 ///              Added support for EBYTE E32-TTL-1W and family serial radio transceivers. These RF95 LoRa based radios
 ///              can deliver reliable messages at up to 7km measured.
+/// \version 1.76 2017-06-23
+///              Fixed a problem with RH_RF95 hanging on transmit under some mysterious circumstances.
+///              Reported by several people at  https://forum.pjrc.com/threads/41878-Probable-race-condition-in-Radiohead-library?p=146601#post146601 <br>
+///              Increased the size of rssi variables to 16 bits to permit RSSI less than -128 as reported by RF95.
 ///
 /// \author  Mike McCauley. DO NOT CONTACT THE AUTHOR DIRECTLY. USE THE MAILING LIST GIVEN ABOVE
 
@@ -754,7 +758,7 @@
 
 // Official version numbers are maintained automatically by Makefile:
 #define RH_VERSION_MAJOR 1
-#define RH_VERSION_MINOR 75
+#define RH_VERSION_MINOR 76
 
 // Symbolic names for currently supported platform types
 #define RH_PLATFORM_ARDUINO          1

--- a/RadioHead.h
+++ b/RadioHead.h
@@ -1,7 +1,7 @@
 // RadioHead.h
 // Author: Mike McCauley (mikem@airspayce.com) DO NOT CONTACT THE AUTHOR DIRECTLY
 // Copyright (C) 2014 Mike McCauley
-// $Id: RadioHead.h,v 1.62 2017/03/08 09:30:47 mikem Exp mikem $
+// $Id: RadioHead.h,v 1.63 2017/06/20 05:21:17 mikem Exp mikem $
 
 /// \mainpage RadioHead Packet Radio library for embedded microprocessors
 ///
@@ -10,7 +10,7 @@
 /// via a variety of common data radios and other transports on a range of embedded microprocessors.
 ///
 /// The version of the package that this documentation refers to can be downloaded 
-/// from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.74.zip
+/// from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.75.zip
 /// You can find the latest version of the documentation at http://www.airspayce.com/mikem/arduino/RadioHead
 ///
 /// You can also find online help and discussion at 
@@ -103,6 +103,9 @@
 /// - RH_CC110
 /// Works with Texas Instruments CC110L transceivers and compatible modules such as Anaren AIR BoosterPack 430BOOST-CC110L
 ///
+/// - RH_E32
+/// Works with EBYTE E32-TTL-1W serial radio transceivers (and possibly other transceivers in the same family)
+///
 /// - RH_ASK
 /// Works with a range of inexpensive ASK (amplitude shift keying) RF transceivers such as RX-B1 
 /// (also known as ST-RX04-ASK) receiver; TX-C1 transmitter and DR3100 transceiver; FS1000A/XY-MK-5V transceiver;
@@ -175,7 +178,7 @@
 ///
 /// - Particle Photon https://store.particle.io/collections/photon and ARM3 based CPU with built-in 
 ///   Wi-Fi transceiver and extensive IoT software suport. RadioHead does not support the built-in transceiver
-///   bt can be used to control other SPI based radios, Serial ports etc.
+///   but can be used to control other SPI based radios, Serial ports etc.
 ///   See below for details on how to build RadioHead for Photon
 ///
 /// - ATtiny built using Arduino IDE 1.0.5 with the arduino-tiny support from https://code.google.com/p/arduino-tiny/
@@ -657,7 +660,9 @@
 ///              http://www.rocketscream.com/blog/product/mini-ultra-pro-with-radio/  (915MHz versions). Updated
 ///              documentation with hints to suit. Caution: requires Arduino 1.6.8 and Arduino SAMD Boards 1.6.5.
 ///              See also http://www.rocketscream.com/blog/2016/03/10/radio-range-test-with-rfm69hcw/
-///              for the vendors tests and range with the RFM69HCW version.
+///              for the vendors tests and range with the RFM69HCW version. They also have an RF95 version equipped with
+///              TCXO temperature controllled oscillator for extra frequency stability and support of very slow and
+///              long range protocols.
 ///              These boards are highly recommended. They also include battery charging support.
 /// \version 1.60 2016-06-25
 ///              Tested with the excellent talk2 Whisper Node boards 
@@ -733,7 +738,14 @@
 ///              Improvements to RH_RF69::setTxPower so it now takes an optional ishighpowermodule
 ///              flag to indicate if the connected module is a high power RFM69HW, and so set the power level
 ///              correctly. Based on code contributed by bob.
-///              
+/// \version 1.75 2017-06-22
+///              Fixed broken compiler issues with RH_RF95::frequencyError() reported by Steve Rogerson.<br>
+///              Testing with the very excellent Rocket Scream boards equipped with RF95 TCXO modules. The
+///              temperature controlled oscillator stabilises the chip enough to be able to use even the slowest
+///              protocol Bw125Cr48Sf4096. Caution, the TCXO model radios are not low power when in sleep (consuming
+///              about ~600 uA, reported by Phang Moh Lim).<br>
+///              Added support for EBYTE E32-TTL-1W and family serial radio transceivers. These RF95 LoRa based radios
+///              can deliver reliable messages at up to 7km measured.
 ///
 /// \author  Mike McCauley. DO NOT CONTACT THE AUTHOR DIRECTLY. USE THE MAILING LIST GIVEN ABOVE
 
@@ -742,7 +754,7 @@
 
 // Official version numbers are maintained automatically by Makefile:
 #define RH_VERSION_MAJOR 1
-#define RH_VERSION_MINOR 74
+#define RH_VERSION_MINOR 75
 
 // Symbolic names for currently supported platform types
 #define RH_PLATFORM_ARDUINO          1

--- a/RadioHead.h
+++ b/RadioHead.h
@@ -1,7 +1,7 @@
 // RadioHead.h
 // Author: Mike McCauley (mikem@airspayce.com) DO NOT CONTACT THE AUTHOR DIRECTLY
 // Copyright (C) 2014 Mike McCauley
-// $Id: RadioHead.h,v 1.68 2017/11/06 00:04:08 mikem Exp mikem $
+// $Id: RadioHead.h,v 1.69 2018/01/06 23:50:45 mikem Exp mikem $
 
 /// \mainpage RadioHead Packet Radio library for embedded microprocessors
 ///
@@ -10,7 +10,7 @@
 /// via a variety of common data radios and other transports on a range of embedded microprocessors.
 ///
 /// The version of the package that this documentation refers to can be downloaded 
-/// from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.81.zip
+/// from http://www.airspayce.com/mikem/arduino/RadioHead/RadioHead-1.82.zip
 /// You can find the latest version of the documentation at http://www.airspayce.com/mikem/arduino/RadioHead
 ///
 /// You can also find online help and discussion at 
@@ -800,7 +800,6 @@
 ///              Added support for SPI transactions in development environments that support it with SPI_HAS_TRANSACTION.
 ///              Tested on ESP32 with RFM-22 and Teensy 3.1 with RF69
 ///              Added support for ESP32, tested with RFM-22 connected by SPI.<br>
-///
 ///\version 1.81 2017-11-15
 ///              RH_CC110, moved setPaTable() from protected to public.<br>
 ///              RH_RF95 modem config Bw125Cr48Sf4096 altered to enable slow daat rate in register 26
@@ -810,6 +809,12 @@
 ///              Fixed a problem where rev 1.80 broke Adafruit M0 LoRa support by declaring 
 ///              bitOrder variable always as a unsigned char. Reported by Guilherme Jardim.<br>
 ///              In RH_RF95, all modes now have AGC enabled, as suggested by Dieter Kneffel.<br>
+/// \version 1.82 2018-01-07
+///              Added guard code to RH_NRF24::waitPacketSent() so that if the transmit never completes for some
+///              reason, the code will eventually return with FALSE.
+///              Added the low-datarate-optimization bit to config for RH_RF95::Bw125Cr48Sf4096.
+///              Fix from Jurie Pieterse to ensure RH_CC110::sleep always enters sleep mode.
+///              Update ESP32 support to include ASK timers. RH_ASK module is now working on ESP32.
 ///
 /// \author  Mike McCauley. DO NOT CONTACT THE AUTHOR DIRECTLY. USE THE GOOGLE LIST GIVEN ABOVE
 
@@ -1056,7 +1061,7 @@ these examples and explanations and extend them to suit your needs.
 
 // Official version numbers are maintained automatically by Makefile:
 #define RH_VERSION_MAJOR 1
-#define RH_VERSION_MINOR 81
+#define RH_VERSION_MINOR 82
 
 // Symbolic names for currently supported platform types
 #define RH_PLATFORM_ARDUINO          1

--- a/examples/ask/ask_receiver/ask_receiver.pde
+++ b/examples/ask/ask_receiver/ask_receiver.pde
@@ -8,7 +8,7 @@
 #include <SPI.h> // Not actualy used but needed to compile
 
 RH_ASK driver;
-// RH_ASK driver(2000, 2, 4, 5); // ESP8266: do not use pin 11
+// RH_ASK driver(2000, 2, 4, 5); // ESP8266 or ESP32: do not use pin 11
 
 void setup()
 {

--- a/examples/ask/ask_receiver/ask_receiver.pde
+++ b/examples/ask/ask_receiver/ask_receiver.pde
@@ -3,12 +3,13 @@
 // Simple example of how to use RadioHead to receive messages
 // with a simple ASK transmitter in a very simple way.
 // Implements a simplex (one-way) receiver with an Rx-B1 module
+// Tested on Arduino Mega, Duemilanova, Uno, Due, Teensy, ESP-12
 
 #include <RH_ASK.h>
-#include <SPI.h> // Not actualy used but needed to compile
+#include <SPI.h> // Not actually used but needed to compile
 
 RH_ASK driver;
-// RH_ASK driver(2000, 2, 4, 5); // ESP8266 or ESP32: do not use pin 11
+// RH_ASK driver(2000, 4, 5, 0); // ESP8266 or ESP32: do not use pin 11 or 2
 
 void setup()
 {

--- a/examples/ask/ask_reliable_datagram_client/ask_reliable_datagram_client.pde
+++ b/examples/ask/ask_reliable_datagram_client/ask_reliable_datagram_client.pde
@@ -14,7 +14,7 @@
 
 // Singleton instance of the radio driver
 RH_ASK driver;
-// RH_ASK driver(2000, 2, 4, 5); // ESP8266: do not use pin 11
+// RH_ASK driver(2000, 2, 4, 5); // ESP8266 or ESP32: do not use pin 11
 
 // Class to manage message delivery and receipt, using the driver declared above
 RHReliableDatagram manager(driver, CLIENT_ADDRESS);

--- a/examples/ask/ask_reliable_datagram_client/ask_reliable_datagram_client.pde
+++ b/examples/ask/ask_reliable_datagram_client/ask_reliable_datagram_client.pde
@@ -3,7 +3,7 @@
 // Example sketch showing how to create a simple addressed, reliable messaging client
 // with the RHReliableDatagram class, using the RH_ASK driver to control a ASK radio.
 // It is designed to work with the other example ask_reliable_datagram_server
-// Tested on Arduino Mega, Duemilanova, Uno, Due, Teensy
+// Tested on Arduino Mega, Duemilanova, Uno, Due, Teensy, ESP-12
 
 #include <RHReliableDatagram.h>
 #include <RH_ASK.h>
@@ -14,7 +14,7 @@
 
 // Singleton instance of the radio driver
 RH_ASK driver;
-// RH_ASK driver(2000, 2, 4, 5); // ESP8266 or ESP32: do not use pin 11
+// RH_ASK driver(2000, 4, 5, 0); // ESP8266 or ESP32: do not use pin 11 or 2
 
 // Class to manage message delivery and receipt, using the driver declared above
 RHReliableDatagram manager(driver, CLIENT_ADDRESS);

--- a/examples/ask/ask_reliable_datagram_server/ask_reliable_datagram_server.pde
+++ b/examples/ask/ask_reliable_datagram_server/ask_reliable_datagram_server.pde
@@ -14,7 +14,7 @@
 
 // Singleton instance of the radio driver
 RH_ASK driver;
-// RH_ASK driver(2000, 2, 4, 5); // ESP8266: do not use pin 11
+// RH_ASK driver(2000, 2, 4, 5); // ESP8266 or ESP32: do not use pin 11
 
 // Class to manage message delivery and receipt, using the driver declared above
 RHReliableDatagram manager(driver, SERVER_ADDRESS);

--- a/examples/ask/ask_reliable_datagram_server/ask_reliable_datagram_server.pde
+++ b/examples/ask/ask_reliable_datagram_server/ask_reliable_datagram_server.pde
@@ -3,7 +3,7 @@
 // Example sketch showing how to create a simple addressed, reliable messaging server
 // with the RHReliableDatagram class, using the RH_ASK driver to control a ASK radio.
 // It is designed to work with the other example ask_reliable_datagram_client
-// Tested on Arduino Mega, Duemilanova, Uno, Due, Teensy
+// Tested on Arduino Mega, Duemilanova, Uno, Due, Teensy, ESP-12
 
 #include <RHReliableDatagram.h>
 #include <RH_ASK.h>
@@ -14,7 +14,7 @@
 
 // Singleton instance of the radio driver
 RH_ASK driver;
-// RH_ASK driver(2000, 2, 4, 5); // ESP8266 or ESP32: do not use pin 11
+// RH_ASK driver(2000, 4, 5, 0); // ESP8266 or ESP32: do not use pin 11 or 2
 
 // Class to manage message delivery and receipt, using the driver declared above
 RHReliableDatagram manager(driver, SERVER_ADDRESS);

--- a/examples/ask/ask_transmitter/ask_transmitter.pde
+++ b/examples/ask/ask_transmitter/ask_transmitter.pde
@@ -8,7 +8,7 @@
 #include <SPI.h> // Not actually used but needed to compile
 
 RH_ASK driver;
-// RH_ASK driver(2000, 2, 4, 5); // ESP8266: do not use pin 11
+// RH_ASK driver(2000, 2, 4, 5); // ESP8266 or ESP32: do not use pin 11
 
 void setup()
 {

--- a/examples/ask/ask_transmitter/ask_transmitter.pde
+++ b/examples/ask/ask_transmitter/ask_transmitter.pde
@@ -3,12 +3,13 @@
 // Simple example of how to use RadioHead to transmit messages
 // with a simple ASK transmitter in a very simple way.
 // Implements a simplex (one-way) transmitter with an TX-C1 module
+// Tested on Arduino Mega, Duemilanova, Uno, Due, Teensy, ESP-12
 
 #include <RH_ASK.h>
 #include <SPI.h> // Not actually used but needed to compile
 
 RH_ASK driver;
-// RH_ASK driver(2000, 2, 4, 5); // ESP8266 or ESP32: do not use pin 11
+// RH_ASK driver(2000, 4, 5, 0); // ESP8266 or ESP32: do not use pin 11 or 2
 
 void setup()
 {

--- a/examples/e32/e32_client/e32_client.pde
+++ b/examples/e32/e32_client/e32_client.pde
@@ -1,0 +1,70 @@
+// e32_client.pde
+// -*- mode: C++ -*-
+// Example sketch showing how to create a simple messageing client
+// with the RH_E32 class. RH_E32 class does not provide for addressing or
+// reliability, so you should only use RH_E32 if you do not need the higher
+// level messaging abilities.
+// It is designed to work with the other example e32_server
+// Tested on Uno with E32-TTL-1W
+
+#include <RH_E32.h>
+#include "SoftwareSerial.h"
+
+SoftwareSerial mySerial(7, 6);
+RH_E32  driver(&mySerial, 4, 5, 8);
+
+void setup() 
+{
+  Serial.begin(9600);
+  while (!Serial) ; // Wait for serial port to be available
+  
+  // Init the serial connection to the E32 module
+  // which is assumned to be running at 9600baud.
+  // If your E32 has been configured to another baud rate, change this:
+  mySerial.begin(9600); 
+  while (!mySerial) ;
+
+  if (!driver.init())
+    Serial.println("init failed");  
+  // Defaults after initialising are:
+  // 433MHz, 21dBm, 5kbps
+  // You can change these as below
+//  if (!driver.setDataRate(RH_E32::DataRate1kbps))
+//    Serial.println("setDataRate failed"); 
+//  if (!driver.setPower(RH_E32::Power30dBm))
+//    Serial.println("setPower failed"); 
+//  if (!driver.setFrequency(434))
+//    Serial.println("setFrequency failed"); 
+}
+
+void loop() 
+{
+  Serial.println("Sending to e32_server");
+  // Send a message to e32_server
+  uint8_t data[] = "Hello World!";
+  driver.send(data, sizeof(data));
+  
+  driver.waitPacketSent();
+  // Now wait for a reply
+  uint8_t buf[RH_E32_MAX_MESSAGE_LEN];
+  uint8_t len = sizeof(buf);
+
+  if (driver.waitAvailableTimeout(10000)) // At 1kbps, reply can take a long time
+  { 
+    // Should be a reply message for us now   
+    if (driver.recv(buf, &len))
+    {
+      Serial.print("got reply: ");
+      Serial.println((char*)buf);
+    }
+    else
+    {
+      Serial.println("recv failed");
+    }
+  }
+  else
+  {
+    Serial.println("No reply, is e32_server running?");
+  }
+  delay(1000);
+}

--- a/examples/e32/e32_server/e32_server.pde
+++ b/examples/e32/e32_server/e32_server.pde
@@ -1,0 +1,64 @@
+// e32_server.pde
+// -*- mode: C++ -*-
+// Example sketch showing how to create a simple messageing client
+// with the RH_E32 class. RH_E32 class does not provide for addressing or
+// reliability, so you should only use RH_E32 if you do not need the higher
+// level messaging abilities.
+// It is designed to work with the other example e32_client
+// Tested on Uno with E32-TTL-1W
+
+#include <RH_E32.h>
+#include "SoftwareSerial.h"
+
+SoftwareSerial mySerial(7, 6);
+RH_E32  driver(&mySerial, 4, 5, 8);
+
+void setup() 
+{
+  Serial.begin(9600);
+  while (!Serial) ; // Wait for serial port to be available
+
+  // Init the serial connection to the E32 module
+  // which is assumned to be running at 9600baud.
+  // If your E32 has been configured to another baud rate, change this:
+  mySerial.begin(9600); 
+  while (!mySerial) ;
+
+  if (!driver.init())
+    Serial.println("init failed");   
+  // Defaults after initialising are:
+  // 433MHz, 21dBm, 5kbps
+  // You can change these as below
+//  if (!driver.setDataRate(RH_E32::DataRate1kbps))
+//    Serial.println("setDataRate failed"); 
+//  if (!driver.setPower(RH_E32::Power30dBm))
+//    Serial.println("setPower failed"); 
+//  if (!driver.setFrequency(434))
+//    Serial.println("setFrequency failed"); 
+}
+
+void loop() 
+{
+  if (driver.available())
+  {
+    // Should be a message for us now   
+    uint8_t buf[RH_E32_MAX_MESSAGE_LEN];
+    uint8_t len = sizeof(buf);
+    if (driver.recv(buf, &len))
+    {
+//      RH_E32::printBuffer("request: ", buf, len);
+      Serial.print("got request: ");
+      Serial.println((char*)buf);
+
+      // Send a reply
+      uint8_t data[] = "And hello back to you";
+      driver.send(data, sizeof(data));
+      driver.waitPacketSent();
+      Serial.println("Sent a reply");
+    }
+    else
+    {
+      Serial.println("recv failed");
+    }
+  }
+}

--- a/examples/nrf24/nrf24_encrypted_client/nrf24_encrypted_client.pde
+++ b/examples/nrf24/nrf24_encrypted_client/nrf24_encrypted_client.pde
@@ -1,0 +1,78 @@
+// nrf24_client.pde
+// -*- mode: C++ -*-
+// Example sketch showing how to create a simple encrypted messageing client
+// with the RH_NRF24 class. RH_NRF24 class does not provide for addressing or
+// reliability, so you should only use RH_NRF24 if you do not need the higher
+// level messaging abilities.
+// It is designed to work with the other example nrf24_encrypted_server.
+// Tested on Duemilanove with Sparkfun NRF25L01 module
+
+#include <SPI.h>
+#include <RH_NRF24.h>
+#include <RHEncryptedDriver.h>
+#include <Speck.h>
+
+// Singleton instance of the radio driver
+RH_NRF24 nrf24;
+// RH_NRF24 nrf24(8, 7); // use this to be electrically compatible with Mirf
+// RH_NRF24 nrf24(8, 10);// For Leonardo, need explicit SS pin
+// RH_NRF24 nrf24(8, 7); // For RFM73 on Anarduino Mini
+
+// You can choose any of several encryption ciphers
+Speck myCipher;   // Instantiate a Speck block ciphering
+// The RHEncryptedDriver acts as a wrapper for the actual radio driver
+RHEncryptedDriver driver(nrf24, myCipher); 
+// The key MUST be the same as the one in the server
+unsigned char encryptkey[16] = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16}; 
+
+void setup() 
+{
+  Serial.begin(9600);
+  while (!Serial) 
+    ; // wait for serial port to connect. Needed for Leonardo only
+  if (!nrf24.init())
+    Serial.println("init failed");
+  // Defaults after init are 2.402 GHz (channel 2), 2Mbps, 0dBm
+  if (!nrf24.setChannel(1))
+    Serial.println("setChannel failed");
+  if (!nrf24.setRF(RH_NRF24::DataRate2Mbps, RH_NRF24::TransmitPower0dBm))
+    Serial.println("setRF failed");  
+
+  // Now set up the encryption key in our cipher
+  myCipher.setKey(encryptkey, sizeof(encryptkey));
+          
+}
+
+
+void loop()
+{
+  Serial.println("Sending to nrf24_encrypted_server");
+  // Send a message to nrf24_server
+  uint8_t data[] = "Hello World!"; // Dont make this too long
+  driver.send(data, sizeof(data));
+  
+  driver.waitPacketSent();
+  // Now wait for a reply
+  uint8_t buf[RH_NRF24_MAX_MESSAGE_LEN];
+  uint8_t len = sizeof(buf);
+
+  if (driver.waitAvailableTimeout(500))
+  { 
+    // Should be a reply message for us now   
+    if (driver.recv(buf, &len))
+    {
+      Serial.print("got reply: ");
+      Serial.println((char*)buf);
+    }
+    else
+    {
+      Serial.println("recv failed");
+    }
+  }
+  else
+  {
+    Serial.println("No reply, is nrf24_encrypted_server running?");
+  }
+  delay(400);
+}
+

--- a/examples/nrf24/nrf24_encrypted_server/nrf24_encrypted_server.pde
+++ b/examples/nrf24/nrf24_encrypted_server/nrf24_encrypted_server.pde
@@ -1,0 +1,69 @@
+// nrf24_server.pde
+// -*- mode: C++ -*-
+// Example sketch showing how to create a simple encrypted messageing server
+// with the RH_NRF24 class. RH_NRF24 class does not provide for addressing or
+// reliability, so you should only use RH_NRF24  if you do not need the higher
+// level messaging abilities.
+// It is designed to work with the other example nrf24_encrypted_client
+
+#include <SPI.h>
+#include <RH_NRF24.h>
+#include <RHEncryptedDriver.h>
+#include <Speck.h>
+
+// Singleton instance of the radio driver
+RH_NRF24 nrf24;
+// RH_NRF24 nrf24(8, 7); // use this to be electrically compatible with Mirf
+// RH_NRF24 nrf24(8, 10);// For Leonardo, need explicit SS pin
+// RH_NRF24 nrf24(8, 7); // For RFM73 on Anarduino Mini
+
+// You can choose any of several encryption ciphers
+Speck myCipher;   // Instantiate a Speck block ciphering
+// The RHEncryptedDriver acts as a wrapper for the actual radio driver
+RHEncryptedDriver driver(nrf24, myCipher); // Instantiate the driver with those two
+// The key MUST be the same as the one in the client
+unsigned char encryptkey[16] = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16}; 
+
+void setup() 
+{
+  Serial.begin(9600);
+  while (!Serial) 
+    ; // wait for serial port to connect. Needed for Leonardo only
+  if (!nrf24.init())
+    Serial.println("init failed");
+  // Defaults after init are 2.402 GHz (channel 2), 2Mbps, 0dBm
+  if (!nrf24.setChannel(1))
+    Serial.println("setChannel failed");
+  if (!nrf24.setRF(RH_NRF24::DataRate2Mbps, RH_NRF24::TransmitPower0dBm))
+    Serial.println("setRF failed"); 
+    
+  // Now set up the encryption key in our cipher
+  myCipher.setKey(encryptkey, sizeof(encryptkey));   
+}
+
+void loop()
+{
+  if (driver.available())
+  {
+    // Should be a message for us now   
+    uint8_t buf[RH_NRF24_MAX_MESSAGE_LEN];
+    uint8_t len = sizeof(buf);
+    if (driver.recv(buf, &len))
+    {
+//      RH_NRF24::printBuffer("request: ", buf, len);
+      Serial.print("got request: ");
+      Serial.println((char*)buf);
+      
+      // Send a reply
+      uint8_t data[] = "And hello back"; // Dont make this too long
+      driver.send(data, sizeof(data));
+      driver.waitPacketSent();
+      Serial.println("Sent a reply");
+    }
+    else
+    {
+      Serial.println("recv failed");
+    }
+  }
+}
+

--- a/examples/rf95/rf95_encrypted_client/rf95_encrypted_client.pde
+++ b/examples/rf95/rf95_encrypted_client/rf95_encrypted_client.pde
@@ -1,4 +1,7 @@
 // LoRa Simple Hello World Client with encrypted communications 
+// In order for this to compile you MUST uncomment the #define RH_ENABLE_ENCRYPTION_MODULE line
+// at the bottom of RadioHead.h, AND you MUST have installed the Crypto directory from arduinolibs:
+// http://rweather.github.io/arduinolibs/index.html
 //  Philippe.Rochat'at'gmail.com
 //  06.07.2017
 

--- a/examples/rf95/rf95_encrypted_client/rf95_encrypted_client.pde
+++ b/examples/rf95/rf95_encrypted_client/rf95_encrypted_client.pde
@@ -1,0 +1,44 @@
+// LoRa Simple Hello World Client with encrypted communications 
+//  Philippe.Rochat'at'gmail.com
+//  06.07.2017
+
+#include <RH_RF95.h>
+#include <RHEncryptedDriver.h>
+#include <Speck.h>
+
+RH_RF95 rf95;     // Instanciate a LoRa driver
+Speck myCipher;   // Instanciate a Speck block ciphering
+RHEncryptedDriver myDriver(rf95, myCipher); // Instantiate the driver with those two
+
+float frequency = 868.0; // Change the frequency here. 
+unsigned char encryptkey[16] = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16}; // The very secret key
+char HWMessage[] = "Hello World ! I'm happy if you can read me";
+uint8_t HWMessageLen;
+
+void setup()
+{
+  HWMessageLen = strlen(HWMessage);
+  Serial.begin(9600);
+  while (!Serial) ; // Wait for serial port to be available
+  Serial.println("LoRa Simple_Encrypted Client");
+  if (!rf95.init())
+    Serial.println("LoRa init failed");
+  // Setup ISM frequency
+  rf95.setFrequency(frequency);
+  // Setup Power,dBm
+  rf95.setTxPower(13);
+  myCipher.setKey(encryptkey, sizeof(encryptkey));
+  Serial.println("Waiting for radio to setup");
+  delay(1000);
+  Serial.println("Setup completed");
+}
+
+void loop()
+{
+  uint8_t data[HWMessageLen+1] = {0};
+  for(uint8_t i = 0; i<= HWMessageLen; i++) data[i] = (uint8_t)HWMessage[i];
+  myDriver.send(data, sizeof(data)); // Send out ID + Sensor data to LoRa gateway
+  Serial.print("Sent: ");
+  Serial.println((char *)&data);
+  delay(4000);
+}

--- a/examples/rf95/rf95_encrypted_server/rf95_encrypted_server.pde
+++ b/examples/rf95/rf95_encrypted_server/rf95_encrypted_server.pde
@@ -1,0 +1,45 @@
+//  LoRa simple server with encrypted communications 
+//  Philippe.Rochat'at'gmail.com
+//  06.07.2017
+
+#include <RH_RF95.h>
+#include <RHEncryptedDriver.h>
+#include <Speck.h>
+
+RH_RF95 rf95;     // Instanciate a LoRa driver
+Speck myCipher;   // Instanciate a Speck block ciphering
+RHEncryptedDriver myDriver(rf95, myCipher); // Instantiate the driver with those two
+
+float frequency = 868.0; // Change the frequency here. 
+unsigned char encryptkey[16]={1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16}; // The very secret key 
+
+void setup() {
+  Serial.begin(9600);
+  while (!Serial) ; // Wait for serial port to be available
+  Serial.println("LoRa Simple_Encrypted Server");
+  if (!rf95.init())
+    Serial.println("LoRa init failed");
+  // Setup ISM frequency
+  rf95.setFrequency(frequency);
+  // Setup Power,dBm
+  rf95.setTxPower(13);
+  myCipher.setKey(encryptkey, 16);
+  delay(4000);
+  Serial.println("Setup completed");
+}
+
+void loop() {
+  if (myDriver.available()) {
+    // Should be a message for us now   
+    uint8_t buf[myDriver.maxMessageLength()];
+    uint8_t len = sizeof(buf);
+    if (myDriver.recv(buf, &len)) {
+      Serial.print("Received: ");
+      Serial.println((char *)&buf);
+    }
+    else
+    {
+        Serial.println("recv failed");
+    }
+  }
+}

--- a/examples/rf95/rf95_encrypted_server/rf95_encrypted_server.pde
+++ b/examples/rf95/rf95_encrypted_server/rf95_encrypted_server.pde
@@ -1,4 +1,7 @@
 //  LoRa simple server with encrypted communications 
+// In order for this to compile you MUST uncomment the #define RH_ENABLE_ENCRYPTION_MODULE line
+// at the bottom of RadioHead.h, AND you MUST have installed the Crypto directory from arduinolibs:
+// http://rweather.github.io/arduinolibs/index.html
 //  Philippe.Rochat'at'gmail.com
 //  06.07.2017
 

--- a/project.cfg
+++ b/project.cfg
@@ -1954,7 +1954,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = RH_ENABLE_ENCRYPTION_MODULE
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
Hi. This PR brings your repo up to the latest RadioHead version (1.85). I did this as a series of commits--one for each version between your repo's current state (1.74) and the latest RadioHead version (1.85). By v1.81, ESP32 and transactional SPI support was added, obviating the need for most of your patches. However, the stock version still doesn't include the Feather examples, nor is it on Github, so I thought that updating your version might be worthwhile. I'm awaiting my Feather, so I haven't tested this extensively yet, but I figured I'd submit it for your review/comment in case it's useful. Thanks!