### PR TITLE
Patch to allow for the ATSAMD51 to compile

### DIFF
--- a/RH_ASK.cpp
+++ b/RH_ASK.cpp
@@ -5,7 +5,7 @@
 
 #include <RH_ASK.h>
 #include <RHCRC.h>
-
+#ifndef __SAMD51__
 #if (RH_PLATFORM == RH_PLATFORM_STM32)
     // Maple etc
 HardwareTimer timer(MAPLE_TIMER);
@@ -866,3 +866,4 @@ void INTERRUPT_ATTR RH_ASK::handleTimerInterrupt()
         transmitTimer(); // Transmitting
 }
 
+#endif


### PR DESCRIPTION
Allows for M4 based boards such as the Adafruit Feather M4 Express and M4 Metro to compile. When compiling for other drivers, this file gets mistakenly included by GCC and the Arduino compiler. The RH_ASK in unusable with the ATSAMD51 in this condition, but I will come back with a fix that adds support and allows for users to also use the ASK library. Solves issue #28 