### PR TITLE
Added error messages for RH_RF95 init

### DIFF
--- a/RH_RF95.cpp
+++ b/RH_RF95.cpp
@@ -20,7 +20,7 @@ PROGMEM static const RH_RF95::ModemConfig MODEM_CONFIG_TABLE[] =
     { 0x92,   0x74,    0x04}, // Bw500Cr45Sf128, AGC enabled
     { 0x48,   0x94,    0x04}, // Bw31_25Cr48Sf512, AGC enabled
     { 0x78,   0xc4,    0x0c}, // Bw125Cr48Sf4096, AGC enabled
-    
+
 };
 
 RH_RF95::RH_RF95(uint8_t slaveSelectPin, uint8_t interruptPin, RHGenericSPI& spi)
@@ -34,13 +34,19 @@ RH_RF95::RH_RF95(uint8_t slaveSelectPin, uint8_t interruptPin, RHGenericSPI& spi
 
 bool RH_RF95::init()
 {
-    if (!RHSPIDriver::init())
-	return false;
+    if (!RHSPIDriver::init()){
+      Serial.println("ERROR: Failed to initialize SPI Driver.");
+      return false;
+    }
+
 
     // Determine the interrupt number that corresponds to the interruptPin
     int interruptNumber = digitalPinToInterrupt(_interruptPin);
-    if (interruptNumber == NOT_AN_INTERRUPT)
-	return false;
+    if (interruptNumber == NOT_AN_INTERRUPT){
+      Serial.println("ERROR: Provided pin does not support interrupts.");
+      return false;
+    }
+
 #ifdef RH_ATTACHINTERRUPT_TAKES_PIN_NUMBER
     interruptNumber = _interruptPin;
 #endif
@@ -49,35 +55,39 @@ bool RH_RF95::init()
     spiUsingInterrupt(interruptNumber);
 
     // No way to check the device type :-(
-    
+
     // Set sleep mode, so we can also set LORA mode:
     spiWrite(RH_RF95_REG_01_OP_MODE, RH_RF95_MODE_SLEEP | RH_RF95_LONG_RANGE_MODE);
     delay(10); // Wait for sleep mode to take over from say, CAD
     // Check we are in sleep mode, with LORA set
     if (spiRead(RH_RF95_REG_01_OP_MODE) != (RH_RF95_MODE_SLEEP | RH_RF95_LONG_RANGE_MODE))
     {
-//	Serial.println(spiRead(RH_RF95_REG_01_OP_MODE), HEX);
-	return false; // No device present?
+      Serial.println("ERROR: Failed to put device in LoRa mode.");
+      Serial.print("RH_RF95_REG_01_OP_MODE: ");
+      Serial.println(spiRead(RH_RF95_REG_01_OP_MODE), HEX);
+	     return false; // No device present?
     }
 
     // Add by Adrien van den Bossche <vandenbo@univ-tlse2.fr> for Teensy
     // ARM M4 requires the below. else pin interrupt doesn't work properly.
     // On all other platforms, its innocuous, belt and braces
-    pinMode(_interruptPin, INPUT); 
+    pinMode(_interruptPin, INPUT);
 
     // Set up interrupt handler
     // Since there are a limited number of interrupt glue functions isr*() available,
     // we can only support a limited number of devices simultaneously
-    // ON some devices, notably most Arduinos, the interrupt pin passed in is actuallt the 
+    // ON some devices, notably most Arduinos, the interrupt pin passed in is actuallt the
     // interrupt number. You have to figure out the interruptnumber-to-interruptpin mapping
     // yourself based on knwledge of what Arduino board you are running on.
     if (_myInterruptIndex == 0xff)
     {
-	// First run, no interrupt allocated yet
-	if (_interruptCount <= RH_RF95_NUM_INTERRUPTS)
-	    _myInterruptIndex = _interruptCount++;
-	else
-	    return false; // Too many devices, not enough interrupt vectors
+	     // First run, no interrupt allocated yet
+	     if (_interruptCount <= RH_RF95_NUM_INTERRUPTS)
+	      _myInterruptIndex = _interruptCount++;
+	     else{
+         Serial.println("ERROR: Insufficient interrupt vectors.");
+         return false; // Too many devices, not enough interrupt vectors
+       }
     }
     _deviceForInterrupt[_myInterruptIndex] = this;
     if (_myInterruptIndex == 0)
@@ -86,8 +96,11 @@ bool RH_RF95::init()
 	attachInterrupt(interruptNumber, isr1, RISING);
     else if (_myInterruptIndex == 2)
 	attachInterrupt(interruptNumber, isr2, RISING);
-    else
-	return false; // Too many devices, not enough interrupt vectors
+    else{
+      Serial.println("ERROR: Failed to attach interrupt pin. Insufficient interrupt vectors.");
+      return false; // Too many devices, not enough interrupt vectors
+    }
+
 
     // Set up FIFO
     // We configure so that we can use the entire 256 byte FIFO for either receive
@@ -118,7 +131,7 @@ bool RH_RF95::init()
 
 // C++ level interrupt handler for this instance
 // LORA is unusual in that it has several interrupt lines, and not a single, combined one.
-// On MiniWirelessLoRa, only one of the several interrupt lines (DI0) from the RFM95 is usefuly 
+// On MiniWirelessLoRa, only one of the several interrupt lines (DI0) from the RFM95 is usefuly
 // connnected to the processor.
 // We use this to get RxDone and TxDone interrupts
 void RH_RF95::handleInterrupt()
@@ -164,11 +177,11 @@ void RH_RF95::handleInterrupt()
 	    _lastRssi -= 157;
 	else
 	    _lastRssi -= 164;
-	    
+
 	// We have received a message.
-	validateRxBuf(); 
+	validateRxBuf();
 	if (_rxBufValid)
-	    setModeIdle(); // Got one 
+	    setModeIdle(); // Got one
     }
     else if (_mode == RHModeTx && irq_flags & RH_RF95_TX_DONE)
     {
@@ -265,7 +278,7 @@ bool RH_RF95::send(const uint8_t* data, uint8_t len)
     waitPacketSent(); // Make sure we dont interrupt an outgoing message
     setModeIdle();
 
-    if (!waitCAD()) 
+    if (!waitCAD())
 	return false;  // Check channel activity
 
     // Position at the beginning of the FIFO
@@ -448,7 +461,7 @@ void RH_RF95::enableTCXO()
     {
 	sleep();
 	spiWrite(RH_RF95_REG_4B_TCXO, (spiRead(RH_RF95_REG_4B_TCXO) | RH_RF95_TCXO_TCXO_INPUT_ON));
-    } 
+    }
 }
 
 // From section 4.1.5 of SX1276/77/78/79

--- a/RH_RF95.cpp
+++ b/RH_RF95.cpp
@@ -5,6 +5,8 @@
 
 #include <RH_RF95.h>
 
+// #define SERIAL_DEBUG // Uncomment to recieve debug information over serial
+
 // Interrupt vectors for the 3 Arduino interrupt pins
 // Each interrupt can be handled by a different instance of RH_RF95, allowing you to have
 // 2 or more LORAs per Arduino
@@ -35,7 +37,9 @@ RH_RF95::RH_RF95(uint8_t slaveSelectPin, uint8_t interruptPin, RHGenericSPI& spi
 bool RH_RF95::init()
 {
     if (!RHSPIDriver::init()){
-      Serial.println("ERROR: Failed to initialize SPI Driver.");
+      #ifdef SERIAL_DEBUG
+        Serial.println(F("ERROR: Failed to initialize SPI Driver."));
+      #endif
       return false;
     }
 
@@ -43,7 +47,9 @@ bool RH_RF95::init()
     // Determine the interrupt number that corresponds to the interruptPin
     int interruptNumber = digitalPinToInterrupt(_interruptPin);
     if (interruptNumber == NOT_AN_INTERRUPT){
-      Serial.println("ERROR: Provided pin does not support interrupts.");
+      #ifdef SERIAL_DEBUG
+        Serial.println(F("ERROR: Provided pin does not support interrupts."));
+      #endif
       return false;
     }
 
@@ -62,10 +68,12 @@ bool RH_RF95::init()
     // Check we are in sleep mode, with LORA set
     if (spiRead(RH_RF95_REG_01_OP_MODE) != (RH_RF95_MODE_SLEEP | RH_RF95_LONG_RANGE_MODE))
     {
-      Serial.println("ERROR: Failed to put device in LoRa mode.");
-      Serial.print("RH_RF95_REG_01_OP_MODE: ");
-      Serial.println(spiRead(RH_RF95_REG_01_OP_MODE), HEX);
-	     return false; // No device present?
+      #ifdef SERIAL_DEBUG
+        Serial.println(F("ERROR: Failed to put device in LoRa mode."));
+        Serial.print(F("RH_RF95_REG_01_OP_MODE: "));
+        Serial.println(spiRead(RH_RF95_REG_01_OP_MODE), HEX);
+      #endif
+	    return false; // No device present?
     }
 
     // Add by Adrien van den Bossche <vandenbo@univ-tlse2.fr> for Teensy
@@ -85,7 +93,9 @@ bool RH_RF95::init()
 	     if (_interruptCount <= RH_RF95_NUM_INTERRUPTS)
 	      _myInterruptIndex = _interruptCount++;
 	     else{
-         Serial.println("ERROR: Insufficient interrupt vectors.");
+         #ifdef SERIAL_DEBUG
+          Serial.println(F("ERROR: Insufficient interrupt vectors."));
+         #endif
          return false; // Too many devices, not enough interrupt vectors
        }
     }
@@ -97,7 +107,9 @@ bool RH_RF95::init()
     else if (_myInterruptIndex == 2)
 	attachInterrupt(interruptNumber, isr2, RISING);
     else{
-      Serial.println("ERROR: Failed to attach interrupt pin. Insufficient interrupt vectors.");
+      #ifdef SERIAL_DEBUG
+        Serial.println(F("ERROR: Failed to attach interrupt pin. Insufficient interrupt vectors."));
+      #endif
       return false; // Too many devices, not enough interrupt vectors
     }
 

--- a/examples/feather/Feather9x_DemoTXRX_OLED/Feather9x_DemoTXRX_OLED.ino
+++ b/examples/feather/Feather9x_DemoTXRX_OLED/Feather9x_DemoTXRX_OLED.ino
@@ -102,6 +102,7 @@ void setup() {
 
   if (!rf95.init()) {
     Serial.println("LoRa radio init failed");
+    Serial.println("Uncomment '#define SERIAL_DEBUG' in RH_RF95.cpp for detailed debug info");
     while (1);
   }
   Serial.println("LoRa radio init OK!");

--- a/examples/feather/Feather9x_RX/Feather9x_RX.ino
+++ b/examples/feather/Feather9x_RX/Feather9x_RX.ino
@@ -96,6 +96,7 @@ void setup()
 
   while (!rf95.init()) {
     Serial.println("LoRa radio init failed");
+    Serial.println("Uncomment '#define SERIAL_DEBUG' in RH_RF95.cpp for detailed debug info");
     while (1);
   }
   Serial.println("LoRa radio init OK!");

--- a/examples/feather/Feather9x_TX/Feather9x_TX.ino
+++ b/examples/feather/Feather9x_TX/Feather9x_TX.ino
@@ -64,7 +64,6 @@
   #define RFM95_INT     4    // "C"
 #endif
 
-
 // Change to 434.0 or other frequency, must match RX's freq!
 #define RF95_FREQ 915.0
 
@@ -93,6 +92,7 @@ void setup()
 
   while (!rf95.init()) {
     Serial.println("LoRa radio init failed");
+    Serial.println("Uncomment '#define SERIAL_DEBUG' in RH_RF95.cpp for detailed debug info");
     while (1);
   }
   Serial.println("LoRa radio init OK!");


### PR DESCRIPTION
Fixes Issue #31: Insufficient error messages on RH_RF95 init.

Adds error messages for each failure (`return false`) condition of the RH_RF95 init function. This will make debugging initialization issues significantly easier for users.