### PR TITLE
Restored ESP compatibility

### DIFF
--- a/RH_CC110.cpp
+++ b/RH_CC110.cpp
@@ -46,13 +46,13 @@ PROGMEM static const RH_CC110::ModemConfig MODEM_CONFIG_TABLE_27MHZ[] =
     {0x0c, 0x00, 0x2d, 0x2f, 0x13, 0x62, 0x1d, 0x1c, 0xc7, 0x00, 0xb0, 0xb6, 0x10, 0xea, 0x2a, 0x00, 0x1f, 0x88, 0x31, 0x09}, // GFSK_Rb250Fd127
 };
 
-// These power outputs are based on the suggested optimum values for 
+// These power outputs are based on the suggested optimum values for
 // multilayer inductors in the 915MHz frequency band. Per table 5-15.
 // Yes these are not linear.
 // Caution: this table is indexed by the values of enum TransmitPower
 // Do not change one without changing the other.
 // If you do not like these values, use setPaTable() directly.
-PROGMEM static const uint8_t paPowerValues[] = 
+PROGMEM static const uint8_t paPowerValues[] =
 {
     0x03, // -30dBm
     0x0e, // -20dBm
@@ -101,12 +101,12 @@ bool RH_CC110::init()
     // Add by Adrien van den Bossche <vandenbo@univ-tlse2.fr> for Teensy
     // ARM M4 requires the below. else pin interrupt doesn't work properly.
     // On all other platforms, its innocuous, belt and braces
-    pinMode(_interruptPin, INPUT); 
+    pinMode(_interruptPin, INPUT);
 
     // Set up interrupt handler
     // Since there are a limited number of interrupt glue functions isr*() available,
     // we can only support a limited number of devices simultaneously
-    // ON some devices, notably most Arduinos, the interrupt pin passed in is actuallt the 
+    // ON some devices, notably most Arduinos, the interrupt pin passed in is actuallt the
     // interrupt number. You have to figure out the interruptnumber-to-interruptpin mapping
     // yourself based on knwledge of what Arduino board you are running on.
     if (_myInterruptIndex == 0xff)
@@ -165,9 +165,9 @@ void RH_CC110::handleInterrupt()
 
 	uint8_t raw_rssi = spiBurstReadRegister(RH_CC110_REG_34_RSSI); // Was set when sync word was detected
 	// Conversion of RSSI value to received power level in dBm per TI section 5.18.2
-	if (raw_rssi >= 128) 
+	if (raw_rssi >= 128)
 	    _lastRssi = (((int16_t)raw_rssi - 256) / 2) - 74;
-	else 
+	else
 	    _lastRssi = ((int16_t)raw_rssi / 2) - 74;
 
 	_bufLen = spiReadRegister(RH_CC110_REG_3F_FIFO);
@@ -180,7 +180,7 @@ void RH_CC110::handleInterrupt()
 	}
 	spiBurstRead(RH_CC110_REG_3F_FIFO | RH_CC110_SPI_BURST_MASK | RH_CC110_SPI_READ_MASK, _buf, _bufLen);
 	// All good so far. See if its for us
-	validateRxBuf(); 
+	validateRxBuf();
 	if (_rxBufValid)
 	    setModeIdle(); // Done
     }
@@ -189,17 +189,17 @@ void RH_CC110::handleInterrupt()
 // These are low level functions that call the interrupt handler for the correct
 // instance of RH_CC110.
 // 3 interrupts allows us to have 3 different devices
-void RH_CC110::isr0()
+ICACHE_RAM_ATTR void RH_CC110::isr0()
 {
     if (_deviceForInterrupt[0])
 	_deviceForInterrupt[0]->handleInterrupt();
 }
-void RH_CC110::isr1()
+ICACHE_RAM_ATTR void RH_CC110::isr1()
 {
     if (_deviceForInterrupt[1])
 	_deviceForInterrupt[1]->handleInterrupt();
 }
-void RH_CC110::isr2()
+ICACHE_RAM_ATTR void RH_CC110::isr2()
 {
     if (_deviceForInterrupt[2])
 	_deviceForInterrupt[2]->handleInterrupt();
@@ -310,7 +310,7 @@ bool RH_CC110::send(const uint8_t* data, uint8_t len)
     waitPacketSent(); // Make sure we dont interrupt an outgoing message
     setModeIdle();
 
-    if (!waitCAD()) 
+    if (!waitCAD())
 	return false;  // Check channel activity
 
     spiWriteRegister(RH_CC110_REG_3F_FIFO, len + RH_CC110_HEADER_LEN);
@@ -373,7 +373,7 @@ void RH_CC110::setModeTx()
 }
 
 uint8_t RH_CC110::statusRead()
-{	
+{
     return spiCommand(RH_CC110_STROBE_3D_SNOP);
 }
 

--- a/RH_CC110.cpp
+++ b/RH_CC110.cpp
@@ -189,17 +189,29 @@ void RH_CC110::handleInterrupt()
 // These are low level functions that call the interrupt handler for the correct
 // instance of RH_CC110.
 // 3 interrupts allows us to have 3 different devices
+#if defined(ESP8266)
 ICACHE_RAM_ATTR void RH_CC110::isr0()
+#else
+void RH_CC110::isr0()
+#endif
 {
     if (_deviceForInterrupt[0])
 	_deviceForInterrupt[0]->handleInterrupt();
 }
+#if defined(ESP8266)
 ICACHE_RAM_ATTR void RH_CC110::isr1()
+#else
+void RH_CC110::isr1()
+#endif
 {
     if (_deviceForInterrupt[1])
 	_deviceForInterrupt[1]->handleInterrupt();
 }
+#if defined(ESP8266)
 ICACHE_RAM_ATTR void RH_CC110::isr2()
+#else
+void RH_CC110::isr2()
+#endif
 {
     if (_deviceForInterrupt[2])
 	_deviceForInterrupt[2]->handleInterrupt();

--- a/RH_CC110.cpp
+++ b/RH_CC110.cpp
@@ -7,6 +7,15 @@
 
 #include <RH_CC110.h>
 
+// interrupt handler and related code must be in RAM on ESP8266,
+// according to issue #46.
+#if defined(ESP8266)
+    #define INTERRUPT_ATTR ICACHE_RAM_ATTR
+#else
+    #define INTERRUPT_ATTR
+#endif
+
+
 // Interrupt vectors for the 3 Arduino interrupt pins
 // Each interrupt can be handled by a different instance of RH_CC110, allowing you to have
 // 2 or more LORAs per Arduino
@@ -189,29 +198,17 @@ void RH_CC110::handleInterrupt()
 // These are low level functions that call the interrupt handler for the correct
 // instance of RH_CC110.
 // 3 interrupts allows us to have 3 different devices
-#if defined(ESP8266)
-ICACHE_RAM_ATTR void RH_CC110::isr0()
-#else
-void RH_CC110::isr0()
-#endif
+void INTERRUPT_ATTR RH_CC110::isr0()
 {
     if (_deviceForInterrupt[0])
 	_deviceForInterrupt[0]->handleInterrupt();
 }
-#if defined(ESP8266)
-ICACHE_RAM_ATTR void RH_CC110::isr1()
-#else
-void RH_CC110::isr1()
-#endif
+void INTERRUPT_ATTR RH_CC110::isr1()
 {
     if (_deviceForInterrupt[1])
 	_deviceForInterrupt[1]->handleInterrupt();
 }
-#if defined(ESP8266)
-ICACHE_RAM_ATTR void RH_CC110::isr2()
-#else
-void RH_CC110::isr2()
-#endif
+void INTERRUPT_ATTR RH_CC110::isr2()
 {
     if (_deviceForInterrupt[2])
 	_deviceForInterrupt[2]->handleInterrupt();

--- a/RH_MRF89.cpp
+++ b/RH_MRF89.cpp
@@ -238,17 +238,29 @@ void RH_MRF89::handleInterrupt()
 // These are low level functions that call the interrupt handler for the correct
 // instance of RH_MRF89.
 // 3 interrupts allows us to have 3 different devices
+#if defined(ESP8266)
 ICACHE_RAM_ATTR void RH_MRF89::isr0()
+#else
+void RH_MRF89::isr0()
+#endif
 {
     if (_deviceForInterrupt[0])
 	_deviceForInterrupt[0]->handleInterrupt();
 }
+#if defined(ESP8266)
 ICACHE_RAM_ATTR void RH_MRF89::isr1()
+#else
+void RH_MRF89::isr1()
+#endif
 {
     if (_deviceForInterrupt[1])
 	_deviceForInterrupt[1]->handleInterrupt();
 }
+#if defined(ESP8266)
 ICACHE_RAM_ATTR void RH_MRF89::isr2()
+#else
+void RH_MRF89::isr2()
+#endif
 {
     if (_deviceForInterrupt[2])
 	_deviceForInterrupt[2]->handleInterrupt();

--- a/RH_MRF89.cpp
+++ b/RH_MRF89.cpp
@@ -9,6 +9,14 @@
 #define LNA_GAIN LNA_GAIN_0_DB
 #define TX_POWER TX_POWER_13_DB
 
+// interrupt handler and related code must be in RAM on ESP8266,
+// according to issue #46.
+#if defined(ESP8266)
+    #define INTERRUPT_ATTR ICACHE_RAM_ATTR
+#else
+    #define INTERRUPT_ATTR
+#endif
+
 // Interrupt vectors for the 3 Arduino interrupt pins
 // Each interrupt can be handled by a different instance of RH_MRF89, allowing you to have
 // 2 or more LORAs per Arduino
@@ -238,29 +246,17 @@ void RH_MRF89::handleInterrupt()
 // These are low level functions that call the interrupt handler for the correct
 // instance of RH_MRF89.
 // 3 interrupts allows us to have 3 different devices
-#if defined(ESP8266)
-ICACHE_RAM_ATTR void RH_MRF89::isr0()
-#else
-void RH_MRF89::isr0()
-#endif
+void INTERRUPT_ATTR RH_MRF89::isr0()
 {
     if (_deviceForInterrupt[0])
 	_deviceForInterrupt[0]->handleInterrupt();
 }
-#if defined(ESP8266)
-ICACHE_RAM_ATTR void RH_MRF89::isr1()
-#else
-void RH_MRF89::isr1()
-#endif
+void INTERRUPT_ATTR RH_MRF89::isr1()
 {
     if (_deviceForInterrupt[1])
 	_deviceForInterrupt[1]->handleInterrupt();
 }
-#if defined(ESP8266)
-ICACHE_RAM_ATTR void RH_MRF89::isr2()
-#else
-void RH_MRF89::isr2()
-#endif
+void INTERRUPT_ATTR RH_MRF89::isr2()
 {
     if (_deviceForInterrupt[2])
 	_deviceForInterrupt[2]->handleInterrupt();

--- a/RH_MRF89.cpp
+++ b/RH_MRF89.cpp
@@ -47,7 +47,7 @@ RH_MRF89::RH_MRF89(uint8_t csconPin, uint8_t csdatPin, uint8_t interruptPin, RHG
 
 bool RH_MRF89::init()
 {
-    // MRF89 data cant handle SPI greater than 1MHz.  
+    // MRF89 data cant handle SPI greater than 1MHz.
     // Sigh on teensy at 1MHz, need special delay after writes, see RHNRFSPIDriver::spiWrite
     _spi.setFrequency(RHGenericSPI::Frequency1MHz);
     if (!RHNRFSPIDriver::init())
@@ -70,8 +70,8 @@ bool RH_MRF89::init()
     // Tell the low level SPI interface we will use SPI within this interrupt
     spiUsingInterrupt(interruptNumber);
 
-    // Make sure we are not in some unexpected mode from a previous run    
-    setOpMode(RH_MRF89_CMOD_STANDBY); 
+    // Make sure we are not in some unexpected mode from a previous run
+    setOpMode(RH_MRF89_CMOD_STANDBY);
 
     // No way to check the device type but lets trivially check there is something there
     // by trying to change a register:
@@ -85,12 +85,12 @@ bool RH_MRF89::init()
     // Add by Adrien van den Bossche <vandenbo@univ-tlse2.fr> for Teensy
     // ARM M4 requires the below. else pin interrupt doesn't work properly.
     // On all other platforms, its innocuous, belt and braces
-    pinMode(_interruptPin, INPUT); 
+    pinMode(_interruptPin, INPUT);
 
     // Set up interrupt handler
     // Since there are a limited number of interrupt glue functions isr*() available,
     // we can only support a limited number of devices simultaneously
-    // On some devices, notably most Arduinos, the interrupt pin passed in is actually the 
+    // On some devices, notably most Arduinos, the interrupt pin passed in is actually the
     // interrupt number. You have to figure out the interruptnumber-to-interruptpin mapping
     // yourself based on knowledge of what Arduino board you are running on.
     if (_myInterruptIndex == 0xff)
@@ -117,7 +117,7 @@ bool RH_MRF89::init()
     // frequency bands 902-915 or 915-928
     // VCOT 60mV
     // OOK max 28kbps
-    // Based on 70622C.pdf, section 3.12: 
+    // Based on 70622C.pdf, section 3.12:
     spiWriteRegister(RH_MRF89_REG_00_GCONREG, RH_MRF89_CMOD_STANDBY | RH_MRF89_FBS_950_960 | RH_MRF89_VCOT_60MV);
     spiWriteRegister(RH_MRF89_REG_01_DMODREG, RH_MRF89_MODSEL_FSK | RH_MRF89_OPMODE_PACKET); // FSK, Packet mode, LNA 0dB
     spiWriteRegister(RH_MRF89_REG_02_FDEVREG, 0); // Set by setModemConfig
@@ -222,33 +222,33 @@ void RH_MRF89::handleInterrupt()
 	    clearRxBuf();
 	    return;
 	}
-	
+
 	// Now drain all the data from the FIFO into _buf
 	uint8_t i;
 	for (i = 0; spiReadRegister(RH_MRF89_REG_0D_FTXRXIREG) & RH_MRF89_FIFOEMPTY; i++)
 	    _buf[i] = spiReadData();
 
 	// All good. See if its for us
-	validateRxBuf(); 
+	validateRxBuf();
 	if (_rxBufValid)
-	    setModeIdle(); // Got one 
+	    setModeIdle(); // Got one
     }
 }
 
 // These are low level functions that call the interrupt handler for the correct
 // instance of RH_MRF89.
 // 3 interrupts allows us to have 3 different devices
-void RH_MRF89::isr0()
+ICACHE_RAM_ATTR void RH_MRF89::isr0()
 {
     if (_deviceForInterrupt[0])
 	_deviceForInterrupt[0]->handleInterrupt();
 }
-void RH_MRF89::isr1()
+ICACHE_RAM_ATTR void RH_MRF89::isr1()
 {
     if (_deviceForInterrupt[1])
 	_deviceForInterrupt[1]->handleInterrupt();
 }
-void RH_MRF89::isr2()
+ICACHE_RAM_ATTR void RH_MRF89::isr2()
 {
     if (_deviceForInterrupt[2])
 	_deviceForInterrupt[2]->handleInterrupt();
@@ -392,11 +392,11 @@ bool RH_MRF89::send(const uint8_t* data, uint8_t len)
 {
     if (len > RH_MRF89_MAX_MESSAGE_LEN)
 	return false;
-    
+
     waitPacketSent(); // Make sure we dont interrupt an outgoing message
     setModeIdle();
-    
-    if (!waitCAD()) 
+
+    if (!waitCAD())
 	return false;  // Check channel activity
 
     // First octet is the length of the chip payload
@@ -507,9 +507,9 @@ bool RH_MRF89::setFrequency(float centre)
     val = (val & ~RH_MRF89_FBS) | (FBS & RH_MRF89_FBS);
     spiWriteRegister(RH_MRF89_REG_00_GCONREG, val);
 
-    spiWriteRegister(RH_MRF89_REG_06_R1CREG, R); 
-    spiWriteRegister(RH_MRF89_REG_07_P1CREG, P); 
-    spiWriteRegister(RH_MRF89_REG_08_S1CREG, S); 
+    spiWriteRegister(RH_MRF89_REG_06_R1CREG, R);
+    spiWriteRegister(RH_MRF89_REG_07_P1CREG, P);
+    spiWriteRegister(RH_MRF89_REG_08_S1CREG, S);
 
     return verifyPLLLock();
 }
@@ -567,4 +567,3 @@ void RH_MRF89::setSyncWords(const uint8_t* syncWords, uint8_t len)
 	}
     }
 }
-

--- a/RH_RF22.cpp
+++ b/RH_RF22.cpp
@@ -303,17 +303,29 @@ void RH_RF22::handleInterrupt()
 // These are low level functions that call the interrupt handler for the correct
 // instance of RH_RF22.
 // 3 interrupts allows us to have 3 different devices
+#if defined(ESP8266)
 ICACHE_RAM_ATTR void RH_RF22::isr0()
+#else
+void RH_RF22::isr0()
+#endif
 {
     if (_deviceForInterrupt[0])
 	_deviceForInterrupt[0]->handleInterrupt();
 }
+#if defined(ESP8266)
 ICACHE_RAM_ATTR void RH_RF22::isr1()
+#else
+void RH_RF22::isr1()
+#endif
 {
     if (_deviceForInterrupt[1])
 	_deviceForInterrupt[1]->handleInterrupt();
 }
+#if defined(ESP8266)
 ICACHE_RAM_ATTR void RH_RF22::isr2()
+#else
+void RH_RF22::isr2()
+#endif
 {
     if (_deviceForInterrupt[2])
 	_deviceForInterrupt[2]->handleInterrupt();

--- a/RH_RF22.cpp
+++ b/RH_RF22.cpp
@@ -12,7 +12,7 @@ RH_RF22* RH_RF22::_deviceForInterrupt[RH_RF22_NUM_INTERRUPTS] = {0, 0, 0};
 uint8_t RH_RF22::_interruptCount = 0; // Index into _deviceForInterrupt for next device
 
 // These are indexed by the values of ModemConfigChoice
-// Canned modem configurations generated with 
+// Canned modem configurations generated with
 // http://www.hoperf.com/upload/rf/RH_RF22B%2023B%2031B%2042B%2043B%20Register%20Settings_RevB1-v5.xls
 // Stored in flash (program) memory to save SRAM
 PROGMEM static const RH_RF22::ModemConfig MODEM_CONFIG_TABLE[] =
@@ -104,7 +104,7 @@ bool RH_RF22::init()
     // Add by Adrien van den Bossche <vandenbo@univ-tlse2.fr> for Teensy
     // ARM M4 requires the below. else pin interrupt doesn't work properly.
     // On all other platforms, its innocuous, belt and braces
-    pinMode(_interruptPin, INPUT); 
+    pinMode(_interruptPin, INPUT);
 
     // Enable interrupt output on the radio. Interrupt line will now go high until
     // an interrupt occurs
@@ -114,7 +114,7 @@ bool RH_RF22::init()
     // Set up interrupt handler
     // Since there are a limited number of interrupt glue functions isr*() available,
     // we can only support a limited number of devices simultaneously
-    // On some devices, notably most Arduinos, the interrupt pin passed in is actually the 
+    // On some devices, notably most Arduinos, the interrupt pin passed in is actually the
     // interrupt number. You have to figure out the interruptnumber-to-interruptpin mapping
     // yourself based on knowledge of what Arduino board you are running on.
     if (_myInterruptIndex == 0xff)
@@ -165,7 +165,7 @@ bool RH_RF22::init()
     setPreambleLength(8);
     uint8_t syncwords[] = { 0x2d, 0xd4 };
     setSyncWords(syncwords, sizeof(syncwords));
-    setPromiscuous(false); 
+    setPromiscuous(false);
 
     // Set some defaults. An innocuous ISM frequency, and reasonable pull-in
     setFrequency(434.0, 0.05);
@@ -216,38 +216,38 @@ void RH_RF22::handleInterrupt()
 	    restartTransmit();
 	else if (_mode == RHModeRx)
 	    clearRxBuf();
-//	Serial.println("IFFERROR");  
+//	Serial.println("IFFERROR");
     }
     // Caution, any delay here may cause a FF underflow or overflow
     if (_lastInterruptFlags[0] & RH_RF22_ITXFFAEM)
     {
-	// See if more data has to be loaded into the Tx FIFO 
+	// See if more data has to be loaded into the Tx FIFO
   	sendNextFragment();
-//	Serial.println("ITXFFAEM");  
+//	Serial.println("ITXFFAEM");
     }
     if (_lastInterruptFlags[0] & RH_RF22_IRXFFAFULL)
     {
 	// Caution, any delay here may cause a FF overflow
 	// Read some data from the Rx FIFO
 	readNextFragment();
-//	Serial.println("IRXFFAFULL"); 
+//	Serial.println("IRXFFAFULL");
     }
     if (_lastInterruptFlags[0] & RH_RF22_IEXT)
     {
 	// This is not enabled by the base code, but users may want to enable it
 	handleExternalInterrupt();
-//	Serial.println("IEXT"); 
+//	Serial.println("IEXT");
     }
     if (_lastInterruptFlags[1] & RH_RF22_IWUT)
     {
 	// This is not enabled by the base code, but users may want to enable it
 	handleWakeupTimerInterrupt();
-//	Serial.println("IWUT"); 
+//	Serial.println("IWUT");
     }
     if (_lastInterruptFlags[0] & RH_RF22_IPKSENT)
     {
-//	Serial.println("IPKSENT");   
-	_txGood++; 
+//	Serial.println("IPKSENT");
+	_txGood++;
 	// Transmission does not automatically clear the tx buffer.
 	// Could retransmit if we wanted
 	// RH_RF22 transitions automatically to Idle
@@ -256,7 +256,7 @@ void RH_RF22::handleInterrupt()
     if (_lastInterruptFlags[0] & RH_RF22_IPKVALID)
     {
 	uint8_t len = spiRead(RH_RF22_REG_4B_RECEIVED_PACKET_LENGTH);
-//	Serial.println("IPKVALID");   
+//	Serial.println("IPKVALID");
 
 	// May have already read one or more fragments
 	// Get any remaining unread octets, based on the expected length
@@ -268,7 +268,7 @@ void RH_RF22::handleInterrupt()
 	    _rxBad++;
 	    _mode = RHModeIdle;
 	    clearRxBuf();
-	    return; // Hmmm receiver buffer overflow. 
+	    return; // Hmmm receiver buffer overflow.
 	}
 
 	spiBurstRead(RH_RF22_REG_7F_FIFO_ACCESS, _buf + _bufLen, len - _bufLen);
@@ -283,7 +283,7 @@ void RH_RF22::handleInterrupt()
     }
     if (_lastInterruptFlags[0] & RH_RF22_ICRCERROR)
     {
-//	Serial.println("ICRCERR");  
+//	Serial.println("ICRCERR");
 	_rxBad++;
 	clearRxBuf();
 	resetRxFifo();
@@ -292,7 +292,7 @@ void RH_RF22::handleInterrupt()
     }
     if (_lastInterruptFlags[1] & RH_RF22_IPREAVAL)
     {
-//	Serial.println("IPREAVAL");  
+//	Serial.println("IPREAVAL");
 	_lastRssi = (int8_t)(-120 + ((spiRead(RH_RF22_REG_26_RSSI) / 2)));
 	_lastPreambleTime = millis();
 	resetRxFifo();
@@ -303,17 +303,17 @@ void RH_RF22::handleInterrupt()
 // These are low level functions that call the interrupt handler for the correct
 // instance of RH_RF22.
 // 3 interrupts allows us to have 3 different devices
-void RH_RF22::isr0()
+ICACHE_RAM_ATTR void RH_RF22::isr0()
 {
     if (_deviceForInterrupt[0])
 	_deviceForInterrupt[0]->handleInterrupt();
 }
-void RH_RF22::isr1()
+ICACHE_RAM_ATTR void RH_RF22::isr1()
 {
     if (_deviceForInterrupt[1])
 	_deviceForInterrupt[1]->handleInterrupt();
 }
-void RH_RF22::isr2()
+ICACHE_RAM_ATTR void RH_RF22::isr2()
 {
     if (_deviceForInterrupt[2])
 	_deviceForInterrupt[2]->handleInterrupt();
@@ -333,7 +333,7 @@ uint8_t RH_RF22::statusRead()
 
 uint8_t RH_RF22::adcRead(uint8_t adcsel,
                       uint8_t adcref ,
-                      uint8_t adcgain, 
+                      uint8_t adcgain,
                       uint8_t adcoffs)
 {
     uint8_t configuration = adcsel | adcref | (adcgain & RH_RF22_ADCGAIN);
@@ -344,7 +344,7 @@ uint8_t RH_RF22::adcRead(uint8_t adcsel,
     // Wait for the DONE bit
     while (!(spiRead(RH_RF22_REG_0F_ADC_CONFIGURATION) & RH_RF22_ADCDONE))
 	;
-    // Return the value  
+    // Return the value
     return spiRead(RH_RF22_REG_11_ADC_VALUE);
 }
 
@@ -352,7 +352,7 @@ uint8_t RH_RF22::temperatureRead(uint8_t tsrange, uint8_t tvoffs)
 {
     spiWrite(RH_RF22_REG_12_TEMPERATURE_SENSOR_CALIBRATION, tsrange | RH_RF22_ENTSOFFS);
     spiWrite(RH_RF22_REG_13_TEMPERATURE_VALUE_OFFSET, tvoffs);
-    return adcRead(RH_RF22_ADCSEL_INTERNAL_TEMPERATURE_SENSOR | RH_RF22_ADCREF_BANDGAP_VOLTAGE); 
+    return adcRead(RH_RF22_ADCSEL_INTERNAL_TEMPERATURE_SENSOR | RH_RF22_ADCREF_BANDGAP_VOLTAGE);
 }
 
 uint16_t RH_RF22::wutRead()
@@ -593,7 +593,7 @@ bool RH_RF22::send(const uint8_t* data, uint8_t len)
     bool ret = true;
     waitPacketSent();
 
-    if (!waitCAD()) 
+    if (!waitCAD())
 	return false;  // Check channel activity
 
     ATOMIC_BLOCK_START;
@@ -614,7 +614,7 @@ bool RH_RF22::fillTxBuf(const uint8_t* data, uint8_t len)
 {
     clearTxBuf();
     if (!len)
-	return false; 
+	return false;
     return appendTxBuf(data, len);
 }
 
@@ -741,4 +741,3 @@ void RH_RF22::setGpioReversed(bool gpioReversed)
 	spiWrite(RH_RF22_REG_0C_GPIO_CONFIGURATION1, 0x15) ; // RX state
     }
 }
-

--- a/RH_RF22.cpp
+++ b/RH_RF22.cpp
@@ -5,6 +5,14 @@
 
 #include <RH_RF22.h>
 
+// interrupt handler and related code must be in RAM on ESP8266,
+// according to issue #46.
+#if defined(ESP8266)
+    #define INTERRUPT_ATTR ICACHE_RAM_ATTR
+#else
+    #define INTERRUPT_ATTR
+#endif
+
 // Interrupt vectors for the 2 Arduino interrupt pins
 // Each interrupt can be handled by a different instance of RH_RF22, allowing you to have
 // 2 RH_RF22s per Arduino
@@ -303,29 +311,17 @@ void RH_RF22::handleInterrupt()
 // These are low level functions that call the interrupt handler for the correct
 // instance of RH_RF22.
 // 3 interrupts allows us to have 3 different devices
-#if defined(ESP8266)
-ICACHE_RAM_ATTR void RH_RF22::isr0()
-#else
-void RH_RF22::isr0()
-#endif
+void INTERRUPT_ATTR RH_RF22::isr0()
 {
     if (_deviceForInterrupt[0])
 	_deviceForInterrupt[0]->handleInterrupt();
 }
-#if defined(ESP8266)
-ICACHE_RAM_ATTR void RH_RF22::isr1()
-#else
-void RH_RF22::isr1()
-#endif
+void INTERRUPT_ATTR RH_RF22::isr1()
 {
     if (_deviceForInterrupt[1])
 	_deviceForInterrupt[1]->handleInterrupt();
 }
-#if defined(ESP8266)
-ICACHE_RAM_ATTR void RH_RF22::isr2()
-#else
-void RH_RF22::isr2()
-#endif
+void INTERRUPT_ATTR RH_RF22::isr2()
 {
     if (_deviceForInterrupt[2])
 	_deviceForInterrupt[2]->handleInterrupt();

--- a/RH_RF24.cpp
+++ b/RH_RF24.cpp
@@ -15,6 +15,13 @@
 //#include "RF24configs/radio_config_Si4464_30_915_2GFSK_5_10.h"
 //#include "RF24configs/radio_config_Si4464_30_915_2GFSK_10_20.h"
 
+// interrupt handler and related code must be in RAM on ESP8266,
+// according to issue #46.
+#if defined(ESP8266)
+    #define INTERRUPT_ATTR ICACHE_RAM_ATTR
+#else
+    #define INTERRUPT_ATTR
+#endif
 
 // Interrupt vectors for the 3 Arduino interrupt pins
 // Each interrupt can be handled by a different instance of RH_RF24, allowing you to have
@@ -265,30 +272,17 @@ void RH_RF24::clearBuffer()
 // These are low level functions that call the interrupt handler for the correct
 // instance of RH_RF24.
 // 3 interrupts allows us to have 3 different devices
-#if defined(ESP8266)
-ICACHE_RAM_ATTR void RH_RF24::isr0()
-#else
-void RH_RF24::isr0()
-#endif
+void INTERRUPT_ATTR RH_RF24::isr0()
 {
     if (_deviceForInterrupt[0])
 	_deviceForInterrupt[0]->handleInterrupt();
 }
-
-#if defined(ESP8266)
-ICACHE_RAM_ATTR void RH_RF24::isr1()
-#else
-void RH_RF24::isr1()
-#endif
+void INTERRUPT_ATTR RH_RF24::isr1()
 {
     if (_deviceForInterrupt[1])
 	_deviceForInterrupt[1]->handleInterrupt();
 }
-#if defined(ESP8266)
-ICACHE_RAM_ATTR void RH_RF24::isr2()
-#else
-void RH_RF24::isr2()
-#endif
+void INTERRUPT_ATTR RH_RF24::isr2()
 {
     if (_deviceForInterrupt[2])
 	_deviceForInterrupt[2]->handleInterrupt();

--- a/RH_RF24.cpp
+++ b/RH_RF24.cpp
@@ -265,17 +265,30 @@ void RH_RF24::clearBuffer()
 // These are low level functions that call the interrupt handler for the correct
 // instance of RH_RF24.
 // 3 interrupts allows us to have 3 different devices
+#if defined(ESP8266)
 ICACHE_RAM_ATTR void RH_RF24::isr0()
+#else
+void RH_RF24::isr0()
+#endif
 {
     if (_deviceForInterrupt[0])
 	_deviceForInterrupt[0]->handleInterrupt();
 }
+
+#if defined(ESP8266)
 ICACHE_RAM_ATTR void RH_RF24::isr1()
+#else
+void RH_RF24::isr1()
+#endif
 {
     if (_deviceForInterrupt[1])
 	_deviceForInterrupt[1]->handleInterrupt();
 }
+#if defined(ESP8266)
 ICACHE_RAM_ATTR void RH_RF24::isr2()
+#else
+void RH_RF24::isr2()
+#endif
 {
     if (_deviceForInterrupt[2])
 	_deviceForInterrupt[2]->handleInterrupt();

--- a/RH_RF24.cpp
+++ b/RH_RF24.cpp
@@ -22,7 +22,7 @@
 RH_RF24* RH_RF24::_deviceForInterrupt[RH_RF24_NUM_INTERRUPTS] = {0, 0, 0};
 uint8_t RH_RF24::_interruptCount = 0; // Index into _deviceForInterrupt for next device
 
-// This configuration data is defined in radio_config_Si4460.h 
+// This configuration data is defined in radio_config_Si4460.h
 // which was generated with the Silicon Labs WDS program
 PROGMEM const uint8_t RF24_CONFIGURATION_DATA[] = RADIO_CONFIGURATION_DATA_ARRAY;
 
@@ -82,12 +82,12 @@ bool RH_RF24::init()
     // Add by Adrien van den Bossche <vandenbo@univ-tlse2.fr> for Teensy
     // ARM M4 requires the below. else pin interrupt doesn't work properly.
     // On all other platforms, its innocuous, belt and braces
-    pinMode(_interruptPin, INPUT); 
+    pinMode(_interruptPin, INPUT);
 
     // Set up interrupt handler
     // Since there are a limited number of interrupt glue functions isr*() available,
     // we can only support a limited number of devices simultaneously
-    // ON some devices, notably most Arduinos, the interrupt pin passed in is actuallt the 
+    // ON some devices, notably most Arduinos, the interrupt pin passed in is actuallt the
     // interrupt number. You have to figure out the interruptnumber-to-interruptpin mapping
     // yourself based on knwledge of what Arduino board you are running on.
     if (_myInterruptIndex == 0xff)
@@ -153,7 +153,7 @@ bool RH_RF24::init()
     setPreambleLength(4);
     // Default freq comes from the radio config file
     // About 2.4dBm on RFM24:
-    setTxPower(0x10); 
+    setTxPower(0x10);
 
     return true;
 }
@@ -192,7 +192,7 @@ void RH_RF24::handleInterrupt()
 	}
 	if (status[2] & RH_RF24_INT_STATUS_PACKET_SENT)
 	{
-	    _txGood++; 
+	    _txGood++;
 	    // Transmission does not automatically clear the tx buffer.
 	    // Could retransmit if we wanted
 	    // RH_RF24 configured to transition automatically to Idle after packet sent
@@ -207,7 +207,7 @@ void RH_RF24::handleInterrupt()
 	    command(RH_RF24_CMD_GET_MODEM_STATUS, NULL, 0, modem_status, sizeof(modem_status));
 	    _lastRssi = modem_status[3];
 	    _lastPreambleTime = millis();
-	    
+
 	    // Save it in our buffer
 	    readNextFragment();
 	    // And see if we have a valid message
@@ -265,17 +265,17 @@ void RH_RF24::clearBuffer()
 // These are low level functions that call the interrupt handler for the correct
 // instance of RH_RF24.
 // 3 interrupts allows us to have 3 different devices
-void RH_RF24::isr0()
+ICACHE_RAM_ATTR void RH_RF24::isr0()
 {
     if (_deviceForInterrupt[0])
 	_deviceForInterrupt[0]->handleInterrupt();
 }
-void RH_RF24::isr1()
+ICACHE_RAM_ATTR void RH_RF24::isr1()
 {
     if (_deviceForInterrupt[1])
 	_deviceForInterrupt[1]->handleInterrupt();
 }
-void RH_RF24::isr2()
+ICACHE_RAM_ATTR void RH_RF24::isr2()
 {
     if (_deviceForInterrupt[2])
 	_deviceForInterrupt[2]->handleInterrupt();
@@ -315,7 +315,7 @@ bool RH_RF24::send(const uint8_t* data, uint8_t len)
     waitPacketSent(); // Make sure we dont interrupt an outgoing message
     setModeIdle(); // Prevent RX while filling the fifo
 
-    if (!waitCAD()) 
+    if (!waitCAD())
 	return false;  // Check channel activity
 
     // Put the payload in the FIFO
@@ -382,7 +382,7 @@ void RH_RF24::readNextFragment()
     // Get the packet length from the RX FIFO length
     uint8_t fifo_info[1];
     command(RH_RF24_CMD_FIFO_INFO, NULL, 0, fifo_info, sizeof(fifo_info));
-    uint8_t fifo_len = fifo_info[0]; 
+    uint8_t fifo_len = fifo_info[0];
 
     // Check for overflow
     if ((_bufLen + fifo_len) > sizeof(_buf))
@@ -430,7 +430,7 @@ bool RH_RF24::setModemConfig(ModemConfigChoice index)
 
 void RH_RF24::setPreambleLength(uint16_t bytes)
 {
-    uint8_t config[] = { (uint8_t)bytes, 0x14, 0x00, 0x00, 
+    uint8_t config[] = { (uint8_t)bytes, 0x14, 0x00, 0x00,
 			 RH_RF24_PREAMBLE_FIRST_1 | RH_RF24_PREAMBLE_LENGTH_BYTES | RH_RF24_PREAMBLE_STANDARD_1010};
     set_properties(RH_RF24_PROPERTY_PREAMBLE_TX_LENGTH, config, sizeof(config));
 }
@@ -477,7 +477,7 @@ bool RH_RF24::setFrequency(float centre, float afcPullInRange)
 	    outdiv = 12, band = 3;
 	else if (centre <= 175.0 && centre >= 142.0)
 	    outdiv = 24, band = 5;
-	else 
+	else
 	    return false;
     }
     else
@@ -496,7 +496,7 @@ bool RH_RF24::setFrequency(float centre, float afcPullInRange)
 	    outdiv = 16, band = 4;
 	else if (centre < 169.0 && centre >= 119.0)
 	    outdiv = 24, band = 5;
-	else 
+	else
 	    return false;
     }
 
@@ -514,10 +514,10 @@ bool RH_RF24::setFrequency(float centre, float afcPullInRange)
     unsigned int n = ((unsigned int)(centre / f_pfd)) - 1;
     float ratio = centre / (float)f_pfd;
     float rest  = ratio - (float)n;
-    unsigned long m = (unsigned long)(rest * 524288UL); 
+    unsigned long m = (unsigned long)(rest * 524288UL);
     unsigned int m2 = m / 0x10000;
     unsigned int m1 = (m - m2 * 0x10000) / 0x100;
-    unsigned int m0 = (m - m2 * 0x10000 - m1 * 0x100); 
+    unsigned int m0 = (m - m2 * 0x10000 - m1 * 0x100);
 
     // PROP_FREQ_CONTROL_GROUP
     uint8_t freq_control[] = { (uint8_t)n, (uint8_t)m2, (uint8_t)m1, (uint8_t)m0 };
@@ -562,7 +562,7 @@ void RH_RF24::setModeRx()
 	// Tell the receiver the max data length we will accept (a TX may have changed it)
 	uint8_t l[] = { sizeof(_buf) };
 	set_properties(RH_RF24_PROPERTY_PKT_FIELD_2_LENGTH_7_0, l, sizeof(l));
-	
+
 	// Set the antenna switch pins using the GPIO, assuming we have an RFM module with antenna switch
 	uint8_t gpio_config[] = { RH_RF24_GPIO_HIGH, RH_RF24_GPIO_LOW };
 	command(RH_RF24_CMD_GPIO_PIN_CFG, gpio_config, sizeof(gpio_config));
@@ -581,7 +581,7 @@ void RH_RF24::setModeTx()
 	uint8_t config[] = { RH_RF24_GPIO_LOW, RH_RF24_GPIO_HIGH };
 	command(RH_RF24_CMD_GPIO_PIN_CFG, config, sizeof(config));
 
-	uint8_t tx_params[] = { 0x00, 
+	uint8_t tx_params[] = { 0x00,
 				(uint8_t)((_idleMode << 4) | RH_RF24_CONDITION_RETRANSMIT_NO | RH_RF24_CONDITION_START_IMMEDIATE)};
 	command(RH_RF24_CMD_START_TX, tx_params, sizeof(tx_params));
 	_mode = RHModeTx;
@@ -620,7 +620,7 @@ void RH_RF24::setTxPower(uint8_t power)
     set_properties(RH_RF24_PROPERTY_PA_MODE, power_properties, sizeof(power_properties));
 }
 
-// Caution: There was a bug in A1 hardware that will not handle 1 byte commands. 
+// Caution: There was a bug in A1 hardware that will not handle 1 byte commands.
 bool RH_RF24::command(uint8_t cmd, const uint8_t* write_buf, uint8_t write_len, uint8_t* read_buf, uint8_t read_len)
 {
     bool   done = false;
@@ -671,11 +671,11 @@ bool RH_RF24::command(uint8_t cmd, const uint8_t* write_buf, uint8_t write_len, 
 
 bool RH_RF24::configure(const uint8_t* commands)
 {
-    // Command strings are constructed in radio_config_Si4460.h 
+    // Command strings are constructed in radio_config_Si4460.h
     // Each command starts with a count of the bytes in that command:
     // <bytecount> <command> <bytecount-2 bytes of args/data>
     uint8_t next_cmd_len;
-    
+
     while (memcpy_P(&next_cmd_len, commands, 1), next_cmd_len > 0)
     {
 	uint8_t buf[20]; // As least big as the biggest permitted command/property list of 15
@@ -688,7 +688,7 @@ bool RH_RF24::configure(const uint8_t* commands)
 
 void RH_RF24::power_on_reset()
 {
-    // Sigh: its necessary to control the SDN pin to reset this ship. 
+    // Sigh: its necessary to control the SDN pin to reset this ship.
     // Tying it to GND does not produce reliable startups
     // Per Si4464 Data Sheet 3.3.2
     digitalWrite(_sdnPin, HIGH); // So we dont get a glitch after setting pinMode OUTPUT
@@ -700,7 +700,7 @@ void RH_RF24::power_on_reset()
 
 bool RH_RF24::cmd_clear_all_interrupts()
 {
-    uint8_t write_buf[] = { 0x00, 0x00, 0x00 }; 
+    uint8_t write_buf[] = { 0x00, 0x00, 0x00 };
     return command(RH_RF24_CMD_GET_INT_STATUS, write_buf, sizeof(write_buf));
 }
 
@@ -794,11 +794,11 @@ PROGMEM static const RH_RF24::CommandInfo commands[] =
 // List of properties to be printed by printRegisters()
 PROGMEM static const uint16_t properties[] =
 {
-    RH_RF24_PROPERTY_GLOBAL_XO_TUNE,                   
-    RH_RF24_PROPERTY_GLOBAL_CLK_CFG,                   
-    RH_RF24_PROPERTY_GLOBAL_LOW_BATT_THRESH,           
-    RH_RF24_PROPERTY_GLOBAL_CONFIG,                    
-    RH_RF24_PROPERTY_GLOBAL_WUT_CONFIG,               
+    RH_RF24_PROPERTY_GLOBAL_XO_TUNE,
+    RH_RF24_PROPERTY_GLOBAL_CLK_CFG,
+    RH_RF24_PROPERTY_GLOBAL_LOW_BATT_THRESH,
+    RH_RF24_PROPERTY_GLOBAL_CONFIG,
+    RH_RF24_PROPERTY_GLOBAL_WUT_CONFIG,
     RH_RF24_PROPERTY_GLOBAL_WUT_M_15_8,
     RH_RF24_PROPERTY_GLOBAL_WUT_M_7_0,
     RH_RF24_PROPERTY_GLOBAL_WUT_R,
@@ -1007,7 +1007,7 @@ PROGMEM static const uint16_t properties[] =
 #define	NUM_PROPERTIES (sizeof(properties)/sizeof(uint16_t))
 
 bool RH_RF24::printRegisters()
-{  
+{
 #ifdef RH_HAVE_SERIAL
     uint8_t i;
     // First print the commands that return interesting data

--- a/RH_RF69.cpp
+++ b/RH_RF69.cpp
@@ -32,7 +32,7 @@ PROGMEM static const RH_RF69::ModemConfig MODEM_CONFIG_TABLE[] =
     // FSK, No Manchester, no shaping, whitening, CRC, no address filtering
     // AFC BW == RX BW == 2 x bit rate
     // Low modulation indexes of ~ 1 at slow speeds do not seem to work very well. Choose MI of 2.
-    { CONFIG_FSK,  0x3e, 0x80, 0x00, 0x52, 0xf4, 0xf4, CONFIG_WHITE}, // FSK_Rb2Fd5      
+    { CONFIG_FSK,  0x3e, 0x80, 0x00, 0x52, 0xf4, 0xf4, CONFIG_WHITE}, // FSK_Rb2Fd5
     { CONFIG_FSK,  0x34, 0x15, 0x00, 0x4f, 0xf4, 0xf4, CONFIG_WHITE}, // FSK_Rb2_4Fd4_8
     { CONFIG_FSK,  0x1a, 0x0b, 0x00, 0x9d, 0xf4, 0xf4, CONFIG_WHITE}, // FSK_Rb4_8Fd9_6
 
@@ -43,7 +43,7 @@ PROGMEM static const RH_RF69::ModemConfig MODEM_CONFIG_TABLE[] =
     { CONFIG_FSK,  0x02, 0x2c, 0x07, 0xae, 0xe2, 0xe2, CONFIG_WHITE}, // FSK_Rb57_6Fd120
     { CONFIG_FSK,  0x01, 0x00, 0x08, 0x00, 0xe1, 0xe1, CONFIG_WHITE}, // FSK_Rb125Fd125
     { CONFIG_FSK,  0x00, 0x80, 0x10, 0x00, 0xe0, 0xe0, CONFIG_WHITE}, // FSK_Rb250Fd250
-    { CONFIG_FSK,  0x02, 0x40, 0x03, 0x33, 0x42, 0x42, CONFIG_WHITE}, // FSK_Rb55555Fd50 
+    { CONFIG_FSK,  0x02, 0x40, 0x03, 0x33, 0x42, 0x42, CONFIG_WHITE}, // FSK_Rb55555Fd50
 
     //  02,        03,   04,   05,   06,   19,   1a,  37
     // GFSK (BT=1.0), No Manchester, whitening, CRC, no address filtering
@@ -59,7 +59,7 @@ PROGMEM static const RH_RF69::ModemConfig MODEM_CONFIG_TABLE[] =
     { CONFIG_GFSK, 0x02, 0x2c, 0x07, 0xae, 0xe2, 0xe2, CONFIG_WHITE}, // GFSK_Rb57_6Fd120
     { CONFIG_GFSK, 0x01, 0x00, 0x08, 0x00, 0xe1, 0xe1, CONFIG_WHITE}, // GFSK_Rb125Fd125
     { CONFIG_GFSK, 0x00, 0x80, 0x10, 0x00, 0xe0, 0xe0, CONFIG_WHITE}, // GFSK_Rb250Fd250
-    { CONFIG_GFSK, 0x02, 0x40, 0x03, 0x33, 0x42, 0x42, CONFIG_WHITE}, // GFSK_Rb55555Fd50 
+    { CONFIG_GFSK, 0x02, 0x40, 0x03, 0x33, 0x42, 0x42, CONFIG_WHITE}, // GFSK_Rb55555Fd50
 
     //  02,        03,   04,   05,   06,   19,   1a,  37
     // OOK, No Manchester, no shaping, whitening, CRC, no address filtering
@@ -124,12 +124,12 @@ bool RH_RF69::init()
     // Add by Adrien van den Bossche <vandenbo@univ-tlse2.fr> for Teensy
     // ARM M4 requires the below. else pin interrupt doesn't work properly.
     // On all other platforms, its innocuous, belt and braces
-    pinMode(_interruptPin, INPUT); 
+    pinMode(_interruptPin, INPUT);
 
     // Set up interrupt handler
     // Since there are a limited number of interrupt glue functions isr*() available,
     // we can only support a limited number of devices simultaneously
-    // ON some devices, notably most Arduinos, the interrupt pin passed in is actuallt the 
+    // ON some devices, notably most Arduinos, the interrupt pin passed in is actuallt the
     // interrupt number. You have to figure out the interruptnumber-to-interruptpin mapping
     // yourself based on knwledge of what Arduino board you are running on.
     if (_myInterruptIndex == 0xff)
@@ -168,7 +168,7 @@ bool RH_RF69::init()
 //    spiWrite(RH_RF69_REG_2E_SYNCCONFIG, RH_RF69_SYNCCONFIG_SYNCON); // auto, tolerance 0
     // PAYLOADLENGTH is default
 //    spiWrite(RH_RF69_REG_38_PAYLOADLENGTH, RH_RF69_FIFO_SIZE); // max size only for RX
-    // PACKETCONFIG 2 is default 
+    // PACKETCONFIG 2 is default
     spiWrite(RH_RF69_REG_6F_TESTDAGC, RH_RF69_TESTDAGC_CONTINUOUSDAGC_IMPROVED_LOWBETAOFF);
     // If high power boost set previously, disable it
     spiWrite(RH_RF69_REG_5A_TESTPA1, RH_RF69_TESTPA1_NORMAL);
@@ -188,7 +188,7 @@ bool RH_RF69::init()
     // No encryption
     setEncryptionKey(NULL);
     // +13dBm, same as power-on default
-    setTxPower(13); 
+    setTxPower(13);
 
     return true;
 }
@@ -225,7 +225,7 @@ void RH_RF69::handleInterrupt()
 
 // Low level function reads the FIFO and checks the address
 // Caution: since we put our headers in what the RH_RF69 considers to be the payload, if encryption is enabled
-// we have to suffer the cost of decryption before we can determine whether the address is acceptable. 
+// we have to suffer the cost of decryption before we can determine whether the address is acceptable.
 // Performance issue?
 void RH_RF69::readFifo()
 {
@@ -263,17 +263,17 @@ void RH_RF69::readFifo()
 // These are low level functions that call the interrupt handler for the correct
 // instance of RH_RF69.
 // 3 interrupts allows us to have 3 different devices
-void RH_RF69::isr0()
+ICACHE_RAM_ATTR void RH_RF69::isr0()
 {
     if (_deviceForInterrupt[0])
 	_deviceForInterrupt[0]->handleInterrupt();
 }
-void RH_RF69::isr1()
+ICACHE_RAM_ATTR void RH_RF69::isr1()
 {
     if (_deviceForInterrupt[1])
 	_deviceForInterrupt[1]->handleInterrupt();
 }
-void RH_RF69::isr2()
+ICACHE_RAM_ATTR void RH_RF69::isr2()
 {
     if (_deviceForInterrupt[2])
 	_deviceForInterrupt[2]->handleInterrupt();
@@ -388,16 +388,16 @@ void RH_RF69::setTxPower(int8_t power, bool ishighpowermodule)
 {
   _power = power;
   uint8_t palevel;
-  
+
   if (ishighpowermodule)
   {
     if (_power < -2)
-      _power = -2; //RFM69HW only works down to -2. 
+      _power = -2; //RFM69HW only works down to -2.
     if (_power <= 13)
     {
       // -2dBm to +13dBm
       //Need PA1 exclusivelly on RFM69HW
-      palevel = RH_RF69_PALEVEL_PA1ON | ((_power + 18) & 
+      palevel = RH_RF69_PALEVEL_PA1ON | ((_power + 18) &
       RH_RF69_PALEVEL_OUTPUTPOWER);
     }
     else if (_power >= 18)
@@ -518,7 +518,7 @@ bool RH_RF69::send(const uint8_t* data, uint8_t len)
     waitPacketSent(); // Make sure we dont interrupt an outgoing message
     setModeIdle(); // Prevent RX while filling the fifo
 
-    if (!waitCAD()) 
+    if (!waitCAD())
 	return false;  // Check channel activity
 
     ATOMIC_BLOCK_START;
@@ -546,7 +546,7 @@ uint8_t RH_RF69::maxMessageLength()
 }
 
 bool RH_RF69::printRegister(uint8_t reg)
-{  
+{
 #ifdef RH_HAVE_SERIAL
     Serial.print(reg, HEX);
     Serial.print(" ");
@@ -556,7 +556,7 @@ bool RH_RF69::printRegister(uint8_t reg)
 }
 
 bool RH_RF69::printRegisters()
-{  
+{
     uint8_t i;
     for (i = 0; i < 0x50; i++)
 	printRegister(i);
@@ -564,6 +564,6 @@ bool RH_RF69::printRegisters()
     printRegister(RH_RF69_REG_58_TESTLNA);
     printRegister(RH_RF69_REG_6F_TESTDAGC);
     printRegister(RH_RF69_REG_71_TESTAFC);
-    
+
     return true;
 }

--- a/RH_RF69.cpp
+++ b/RH_RF69.cpp
@@ -263,17 +263,30 @@ void RH_RF69::readFifo()
 // These are low level functions that call the interrupt handler for the correct
 // instance of RH_RF69.
 // 3 interrupts allows us to have 3 different devices
+#if defined(ESP8266)
 ICACHE_RAM_ATTR void RH_RF69::isr0()
+#else
+void RH_RF69::isr0()
+#endif
 {
     if (_deviceForInterrupt[0])
 	_deviceForInterrupt[0]->handleInterrupt();
 }
+
+#if defined(ESP8266)
 ICACHE_RAM_ATTR void RH_RF69::isr1()
+#else
+void RH_RF69::isr1()
+#endif
 {
     if (_deviceForInterrupt[1])
 	_deviceForInterrupt[1]->handleInterrupt();
 }
+#if defined(ESP8266)
 ICACHE_RAM_ATTR void RH_RF69::isr2()
+#else
+void RH_RF69::isr2()
+#endif
 {
     if (_deviceForInterrupt[2])
 	_deviceForInterrupt[2]->handleInterrupt();

--- a/RH_RF69.cpp
+++ b/RH_RF69.cpp
@@ -5,6 +5,14 @@
 
 #include <RH_RF69.h>
 
+// interrupt handler and related code must be in RAM on ESP8266,
+// according to issue #46.
+#if defined(ESP8266)
+    #define INTERRUPT_ATTR ICACHE_RAM_ATTR
+#else
+    #define INTERRUPT_ATTR
+#endif
+
 // Interrupt vectors for the 3 Arduino interrupt pins
 // Each interrupt can be handled by a different instance of RH_RF69, allowing you to have
 // 2 or more RF69s per Arduino
@@ -263,30 +271,17 @@ void RH_RF69::readFifo()
 // These are low level functions that call the interrupt handler for the correct
 // instance of RH_RF69.
 // 3 interrupts allows us to have 3 different devices
-#if defined(ESP8266)
-ICACHE_RAM_ATTR void RH_RF69::isr0()
-#else
-void RH_RF69::isr0()
-#endif
+void INTERRUPT_ATTR RH_RF69::isr0()
 {
     if (_deviceForInterrupt[0])
 	_deviceForInterrupt[0]->handleInterrupt();
 }
-
-#if defined(ESP8266)
-ICACHE_RAM_ATTR void RH_RF69::isr1()
-#else
-void RH_RF69::isr1()
-#endif
+void INTERRUPT_ATTR RH_RF69::isr1()
 {
     if (_deviceForInterrupt[1])
 	_deviceForInterrupt[1]->handleInterrupt();
 }
-#if defined(ESP8266)
-ICACHE_RAM_ATTR void RH_RF69::isr2()
-#else
-void RH_RF69::isr2()
-#endif
+void INTERRUPT_ATTR RH_RF69::isr2()
 {
     if (_deviceForInterrupt[2])
 	_deviceForInterrupt[2]->handleInterrupt();

--- a/RH_RF95.cpp
+++ b/RH_RF95.cpp
@@ -214,17 +214,17 @@ void RH_RF95::handleInterrupt()
 // These are low level functions that call the interrupt handler for the correct
 // instance of RH_RF95.
 // 3 interrupts allows us to have 3 different devices
-void RH_RF95::isr0()
+ICACHE_RAM_ATTR void RH_RF95::isr0()
 {
     if (_deviceForInterrupt[0])
 	_deviceForInterrupt[0]->handleInterrupt();
 }
-void RH_RF95::isr1()
+ICACHE_RAM_ATTR void RH_RF95::isr1()
 {
     if (_deviceForInterrupt[1])
 	_deviceForInterrupt[1]->handleInterrupt();
 }
-void RH_RF95::isr2()
+ICACHE_RAM_ATTR void RH_RF95::isr2()
 {
     if (_deviceForInterrupt[2])
 	_deviceForInterrupt[2]->handleInterrupt();

--- a/RH_RF95.cpp
+++ b/RH_RF95.cpp
@@ -214,17 +214,30 @@ void RH_RF95::handleInterrupt()
 // These are low level functions that call the interrupt handler for the correct
 // instance of RH_RF95.
 // 3 interrupts allows us to have 3 different devices
+#if defined(ESP8266)
 ICACHE_RAM_ATTR void RH_RF95::isr0()
+#else
+void RH_RF95::isr0()
+#endif
 {
     if (_deviceForInterrupt[0])
 	_deviceForInterrupt[0]->handleInterrupt();
 }
+
+#if defined(ESP8266)
 ICACHE_RAM_ATTR void RH_RF95::isr1()
+#else
+void RH_RF95::isr1()
+#endif
 {
     if (_deviceForInterrupt[1])
 	_deviceForInterrupt[1]->handleInterrupt();
 }
+#if defined(ESP8266)
 ICACHE_RAM_ATTR void RH_RF95::isr2()
+#else
+void RH_RF95::isr2()
+#endif
 {
     if (_deviceForInterrupt[2])
 	_deviceForInterrupt[2]->handleInterrupt();

--- a/RH_RF95.cpp
+++ b/RH_RF95.cpp
@@ -5,6 +5,14 @@
 
 #include <RH_RF95.h>
 
+// interrupt handler and related code must be in RAM on ESP8266,
+// according to issue #46.
+#if defined(ESP8266)
+    #define INTERRUPT_ATTR ICACHE_RAM_ATTR
+#else
+    #define INTERRUPT_ATTR
+#endif
+
 // #define SERIAL_DEBUG // Uncomment to recieve debug information over serial
 
 // Interrupt vectors for the 3 Arduino interrupt pins
@@ -214,30 +222,17 @@ void RH_RF95::handleInterrupt()
 // These are low level functions that call the interrupt handler for the correct
 // instance of RH_RF95.
 // 3 interrupts allows us to have 3 different devices
-#if defined(ESP8266)
-ICACHE_RAM_ATTR void RH_RF95::isr0()
-#else
-void RH_RF95::isr0()
-#endif
+void INTERRUPT_ATTR RH_RF95::isr0()
 {
     if (_deviceForInterrupt[0])
 	_deviceForInterrupt[0]->handleInterrupt();
 }
-
-#if defined(ESP8266)
-ICACHE_RAM_ATTR void RH_RF95::isr1()
-#else
-void RH_RF95::isr1()
-#endif
+void INTERRUPT_ATTR RH_RF95::isr1()
 {
     if (_deviceForInterrupt[1])
 	_deviceForInterrupt[1]->handleInterrupt();
 }
-#if defined(ESP8266)
-ICACHE_RAM_ATTR void RH_RF95::isr2()
-#else
-void RH_RF95::isr2()
-#endif
+void INTERRUPT_ATTR RH_RF95::isr2()
 {
     if (_deviceForInterrupt[2])
 	_deviceForInterrupt[2]->handleInterrupt();


### PR DESCRIPTION
- Added ICACHE_RAM_ATTR before isr functions to restore esp compatibility:
[#6127](https://github.com/esp8266/Arduino/issues/6127)
- Removed some trailing whitespaces