### PR TITLE
[RF95] txpower bug - cfg register gets overwritten

### DIFF
--- a/RH_RF95.cpp
+++ b/RH_RF95.cpp
@@ -427,7 +427,7 @@ void RH_RF95::setTxPower(int8_t power, bool useRFO)
 	// The documentation is pretty confusing on this topic: PaSelect says the max power is 20dBm,
 	// but OutputPower claims it would be 17dBm.
 	// My measurements show 20dBm is correct
-	spiWrite(RH_RF95_REG_09_PA_CONFIG, RH_RF95_PA_SELECT | (power-5));
+	spiWrite(RH_RF95_REG_09_PA_CONFIG, RH_RF95_PA_SELECT | RH_RF95_MAX_POWER | (power-2));
     }
 }
 


### PR DESCRIPTION
Activating PABoost register is done in line 418 but but overwritten in line 439 where the high bit is cleared again, resulting in an terrible transmission range compared. Simple or-ing the high bit into the write command fixes that and allows for maximum transmission power.