### PR TITLE
fix build with nrf52840

### DIFF
--- a/RHHardwareSPI.cpp
+++ b/RHHardwareSPI.cpp
@@ -74,7 +74,7 @@ void RHHardwareSPI::begin()
    else
        frequency = 1000000;
 
-#if ((RH_PLATFORM == RH_PLATFORM_ARDUINO) && defined (__arm__) && (defined(ARDUINO_SAM_DUE) || defined(ARDUINO_ARCH_SAMD))) || defined(NRF52) || defined(ARDUINO_ARCH_STM32F1) || defined(ARDUINO_ARCH_STM32F4) || defined(ARDUINO_ARCH_ARDUINO_CORE_STM32)
+#if ((RH_PLATFORM == RH_PLATFORM_ARDUINO) && defined (__arm__) && (defined(ARDUINO_SAM_DUE) || defined(ARDUINO_ARCH_SAMD))) ||  defined(NRF52_SERIES) || defined(ARDUINO_ARCH_STM32F1) || defined(ARDUINO_ARCH_STM32F4) || defined(ARDUINO_ARCH_ARDUINO_CORE_STM32)
     // Arduino Due in 1.5.5 has its own BitOrder :-(
     // So too does Arduino Zero
     // So too does rogerclarkmelbourne/Arduino_STM32
@@ -123,7 +123,7 @@ void RHHardwareSPI::begin()
     // Temporary work-around due to problem where avr_emulation.h does not work properly for the setDataMode() cal
     SPCR &= ~SPI_MODE_MASK;
 #else
- #if ((RH_PLATFORM == RH_PLATFORM_ARDUINO) && defined (__arm__) && defined(ARDUINO_ARCH_SAMD)) || defined(NRF52)
+ #if ((RH_PLATFORM == RH_PLATFORM_ARDUINO) && defined (__arm__) && defined(ARDUINO_ARCH_SAMD)) || defined(NRF52_SERIES)
     // Zero requires begin() before anything else :-)
     SPI.begin();
  #endif
@@ -131,7 +131,7 @@ void RHHardwareSPI::begin()
     SPI.setDataMode(dataMode);
 #endif
 
-#if ((RH_PLATFORM == RH_PLATFORM_ARDUINO) && defined (__arm__) && (defined(ARDUINO_SAM_DUE) || defined(ARDUINO_ARCH_SAMD))) || defined(NRF52) || defined (ARDUINO_ARCH_STM32F1) || defined(ARDUINO_ARCH_STM32F4)
+#if ((RH_PLATFORM == RH_PLATFORM_ARDUINO) && defined (__arm__) && (defined(ARDUINO_SAM_DUE) || defined(ARDUINO_ARCH_SAMD))) || defined(NRF52_SERIES) || defined (ARDUINO_ARCH_STM32F1) || defined(ARDUINO_ARCH_STM32F4)
     // Arduino Due in 1.5.5 has its own BitOrder :-(
     // So too does Arduino Zero
     // So too does rogerclarkmelbourne/Arduino_STM32

--- a/RadioHead.h
+++ b/RadioHead.h
@@ -1136,7 +1136,7 @@ these examples and explanations and extend them to suit your needs.
   #define RH_PLATFORM RH_PLATFORM_UNO32
  #elif defined(NRF51)
   #define RH_PLATFORM RH_PLATFORM_NRF51
- #elif defined(NRF52)
+ #elif defined(NRF52_SERIES)
   #define RH_PLATFORM RH_PLATFORM_NRF52
  #elif defined(ESP8266)
   #define RH_PLATFORM RH_PLATFORM_ESP8266

--- a/examples/feather/Feather9x_RX/Feather9x_RX.ino
+++ b/examples/feather/Feather9x_RX/Feather9x_RX.ino
@@ -57,7 +57,7 @@
   #define RFM95_CS      33   // "B"
   #define RFM95_INT     12   //  next to A
 
-#elif defined(NRF52)  
+#elif defined(NRF52_SERIES)
   /* nRF52832 feather w/wing */
   #define RFM95_RST     7   // "A"
   #define RFM95_CS      11   // "B"

--- a/examples/feather/Feather9x_TX/Feather9x_TX.ino
+++ b/examples/feather/Feather9x_TX/Feather9x_TX.ino
@@ -57,7 +57,7 @@
   #define RFM95_CS      33   // "B"
   #define RFM95_INT     12   //  next to A
 
-#elif defined(NRF52)  
+#elif defined(NRF52_SERIES)
   /* nRF52832 feather w/wing */
   #define RFM95_RST     7   // "A"
   #define RFM95_CS      11   // "B"


### PR DESCRIPTION
Fix build with nrf52840, root cause is NRF52 is only defined for nrf52832. The common macro for both 832 and 840 is NRF52_SERIES. fix #https://github.com/adafruit/RadioHead/issues/65

TODO: to prevent build issue, I will make an pr to add github action for this repo after this one.