### PR TITLE
Update examples for Feather RP2040 RFM

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -11,7 +11,6 @@ jobs:
           - 'feather_m0_express'
           - 'feather_esp32'
           - 'feather_esp32s2'
-          - 'nrf52832'
           - 'nrf52840'
 
     runs-on: ubuntu-latest

--- a/examples/feather/Feather9x_DemoTXRX_OLED/Feather9x_DemoTXRX_OLED.ino
+++ b/examples/feather/Feather9x_DemoTXRX_OLED/Feather9x_DemoTXRX_OLED.ino
@@ -13,7 +13,7 @@ Adafruit_SSD1306 oled = Adafruit_SSD1306();
   #define BUTTON_B 16
   #define BUTTON_C  2
   #define LED       0
-#elif defined(ESP32)
+#elif defined(ESP32) && !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2)
   #define BUTTON_A 15
   #define BUTTON_B 32
   #define BUTTON_C 14

--- a/examples/feather/Feather9x_DemoTXRX_OLED/Feather9x_DemoTXRX_OLED.ino
+++ b/examples/feather/Feather9x_DemoTXRX_OLED/Feather9x_DemoTXRX_OLED.ino
@@ -1,17 +1,19 @@
 #include <SPI.h>
 #include <RH_RF95.h>
-
 #include <Wire.h>
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
 
+/************ OLED Setup ***************/
+
 Adafruit_SSD1306 oled = Adafruit_SSD1306();
+
 #if defined(ESP8266)
-  #define BUTTON_A 0
+  #define BUTTON_A  0
   #define BUTTON_B 16
-  #define BUTTON_C 2
-  #define LED      0
-#elif defined(ESP32) && !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2)
+  #define BUTTON_C  2
+  #define LED       0
+#elif defined(ESP32)
   #define BUTTON_A 15
   #define BUTTON_B 32
   #define BUTTON_C 14
@@ -20,65 +22,84 @@ Adafruit_SSD1306 oled = Adafruit_SSD1306();
   #define BUTTON_A PA15
   #define BUTTON_B PC7
   #define BUTTON_C PC5
-  #define LED PB5
+  #define LED      PB5
 #elif defined(TEENSYDUINO)
-  #define BUTTON_A 4
-  #define BUTTON_B 3
-  #define BUTTON_C 8
-  #define LED 13
+  #define BUTTON_A  4
+  #define BUTTON_B  3
+  #define BUTTON_C  8
+  #define LED      13
 #elif defined(ARDUINO_NRF52832_FEATHER)
   #define BUTTON_A 31
   #define BUTTON_B 30
   #define BUTTON_C 27
-  #define LED 17
-#else // 32u4, M0, ESP32S2, and 328p
-  #define BUTTON_A 9
-  #define BUTTON_B 6
-  #define BUTTON_C 5
+  #define LED      17
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040_RFM)
+  #define BUTTON_A  9
+  #define BUTTON_B  6
+  #define BUTTON_C  5
+  #define LED      LED_BUILTIN
+#else  // 32u4, M0, and 328p
+  #define BUTTON_A  9
+  #define BUTTON_B  6
+  #define BUTTON_C  5
   #define LED      13
 #endif
 
-
-#if defined (__AVR_ATmega32U4__) // Feather 32u4 w/Radio
-  #define RFM95_CS      8
-  #define RFM95_INT     7
-  #define RFM95_RST     4
-#endif
-
-#if defined(ARDUINO_SAMD_FEATHER_M0)
-  // Feather M0 w/Radio
-  #define RFM95_CS      8
-  #define RFM95_INT     3
-  #define RFM95_RST     4
-#endif
-
-#if defined (__AVR_ATmega328P__)  // Feather 328P w/wing
-  #define RFM95_INT     3  // 
-  #define RFM95_CS      4  //
-  #define RFM95_RST     2  // "A"
-#endif
-
-#if defined(ESP32)    // ESP32 feather w/wing
-  #define RFM95_RST     13   // same as LED
-  #define RFM95_CS      33   // "B"
-  #define RFM95_INT     27   // "A"
-#endif
-
-#if defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_NRF52840_FEATHER_SENSE)
-  #define RFM95_INT     9  // "A"
-  #define RFM95_CS      10  // "B"
-  #define RFM95_RST     11  // "C"
-#endif
-
-#if defined(ARDUINO_NRF52832_FEATHER)
-  /* nRF52832 feather w/wing */
-  #define RFM95_RST     7   // "A"
-  #define RFM95_CS      11   // "B"
-  #define RFM95_INT     31   // "C"
-#endif
+/************ Radio Setup ***************/
 
 // Change to 434.0 or other frequency, must match RX's freq!
 #define RF95_FREQ 915.0
+
+// First 3 here are boards w/radio BUILT-IN. Boards using FeatherWing follow.
+#if defined (__AVR_ATmega32U4__)  // Feather 32u4 w/Radio
+  #define RFM95_CS    8
+  #define RFM95_INT   7
+  #define RFM95_RST   4
+  #define LED        13
+
+#elif defined(ADAFRUIT_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ARDUINO_SAMD_FEATHER_M0)  // Feather M0 w/Radio
+  #define RFM95_CS    8
+  #define RFM95_INT   3
+  #define RFM95_RST   4
+  #define LED        13
+
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040_RFM)  // Feather RP2040 w/Radio
+  #define RFM95_CS   16
+  #define RFM95_INT  21
+  #define RFM95_RST  17
+  #define LED        LED_BUILTIN
+
+#elif defined (__AVR_ATmega328P__)  // Feather 328P w/wing
+  #define RFM95_CS    4  //
+  #define RFM95_INT   3  //
+  #define RFM95_RST   2  // "A"
+  #define LED        13
+
+#elif defined(ESP8266)  // ESP8266 feather w/wing
+  #define RFM95_CS    2  // "E"
+  #define RFM95_INT  15  // "B"
+  #define RFM95_RST  16  // "D"
+  #define LED         0
+
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_NRF52840_FEATHER_SENSE)
+  #define RFM95_CS   10  // "B"
+  #define RFM95_INT   9  // "A"
+  #define RFM95_RST  11  // "C"
+  #define LED        13
+
+#elif defined(ESP32)  // ESP32 feather w/wing
+  #define RFM95_CS   33  // "B"
+  #define RFM95_INT  27  // "A"
+  #define RFM95_RST  13  // same as LED
+  #define LED        13
+
+#elif defined(ARDUINO_NRF52832_FEATHER)  // nRF52832 feather w/wing
+  #define RFM95_CS   11  // "B"
+  #define RFM95_INT  31  // "C"
+  #define RFM95_RST   7  // "A"
+  #define LED        17
+
+#endif
 
 int16_t packetnum = 0;  // packet counter, we increment per xmission
 
@@ -88,7 +109,7 @@ RH_RF95 rf95(RFM95_CS, RFM95_INT);
 void setup() {
   delay(500);
   Serial.begin(115200);
-  while (!Serial) { delay(1); } // wait until serial console is open, remove if not tethered to computer
+  while (!Serial) delay(1); // wait until serial console is open, remove if not tethered to computer
 
   // Initialize OLED display
   oled.begin(SSD1306_SWITCHCAPVCC, 0x3C);  // initialize with the I2C addr 0x3C (for the 128x32)
@@ -97,17 +118,16 @@ void setup() {
   oled.clearDisplay();
   oled.display();
 
-
   pinMode(BUTTON_A, INPUT_PULLUP);
   pinMode(BUTTON_B, INPUT_PULLUP);
   pinMode(BUTTON_C, INPUT_PULLUP);
-  
-  pinMode(LED, OUTPUT);     
+
+  pinMode(LED, OUTPUT);
   pinMode(RFM95_RST, OUTPUT);
   digitalWrite(RFM95_RST, HIGH);
 
   Serial.println("Feather LoRa RX/TX Test!");
-  
+
   // manual reset
   digitalWrite(RFM95_RST, LOW);
   delay(10);
@@ -128,8 +148,6 @@ void setup() {
   }
 
   rf95.setTxPower(23, false);
-  
-  pinMode(LED, OUTPUT);
 
   Serial.print("LoRa radio @"); Serial.print((int)RF95_FREQ); Serial.println(" MHz");
 
@@ -147,10 +165,10 @@ void setup() {
 
 void loop() {
   if (rf95.available()) {
-    // Should be a message for us now   
+    // Should be a message for us now
     uint8_t buf[RH_RF95_MAX_MESSAGE_LEN];
     uint8_t len = sizeof(buf);
-    
+
     if (! rf95.recv(buf, &len)) {
       Serial.println("Receive failed");
       return;
@@ -164,13 +182,11 @@ void loop() {
     oled.setCursor(0,0);
     oled.println((char*)buf);
     oled.print("RSSI: "); oled.print(rf95.lastRssi());
-    oled.display(); 
+    oled.display();
   }
-  
-  if (!digitalRead(BUTTON_A) || !digitalRead(BUTTON_B) || !digitalRead(BUTTON_C))
-  {
+
+  if (!digitalRead(BUTTON_A) || !digitalRead(BUTTON_B) || !digitalRead(BUTTON_C)) {
     Serial.println("Button pressed!");
-    
     char radiopacket[20] = "Button #";
     if (!digitalRead(BUTTON_A)) radiopacket[8] = 'A';
     if (!digitalRead(BUTTON_B)) radiopacket[8] = 'B';

--- a/examples/feather/Feather9x_RX/Feather9x_RX.ino
+++ b/examples/feather/Feather9x_RX/Feather9x_RX.ino
@@ -9,73 +9,76 @@
 #include <SPI.h>
 #include <RH_RF95.h>
 
-/* for Feather32u4 RFM9x
-#define RFM95_CS 8
-#define RFM95_RST 4
-#define RFM95_INT 7
-*/
+// First 3 here are boards w/radio BUILT-IN. Boards using FeatherWing follow.
+#if defined (__AVR_ATmega32U4__)  // Feather 32u4 w/Radio
+  #define RFM95_CS    8
+  #define RFM95_INT   7
+  #define RFM95_RST   4
 
-/* for feather m0 RFM9x
-#define RFM95_CS 8
-#define RFM95_RST 4
-#define RFM95_INT 3
-*/
+#elif defined(ADAFRUIT_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ARDUINO_SAMD_FEATHER_M0)  // Feather M0 w/Radio
+  #define RFM95_CS    8
+  #define RFM95_INT   3
+  #define RFM95_RST   4
 
-/* for shield 
-#define RFM95_CS 10
-#define RFM95_RST 9
-#define RFM95_INT 7
-*/
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040_RFM)  // Feather RP2040 w/Radio
+  #define RFM95_CS   16
+  #define RFM95_INT  21
+  #define RFM95_RST  17
 
-/* Feather 32u4 w/wing
-#define RFM95_RST     11   // "A"
-#define RFM95_CS      10   // "B"
-#define RFM95_INT     2    // "SDA" (only SDA/SCL/RX/TX have IRQ!)
-*/
+#elif defined (__AVR_ATmega328P__)  // Feather 328P w/wing
+  #define RFM95_CS    4  //
+  #define RFM95_INT   3  //
+  #define RFM95_RST   2  // "A"
 
-/* Feather m0 w/wing 
-#define RFM95_RST     11   // "A"
-#define RFM95_CS      10   // "B"
-#define RFM95_INT     6    // "D"
-*/
-
-#if defined(ESP8266)
-  /* for ESP w/featherwing */ 
-  #define RFM95_CS  2    // "E"
-  #define RFM95_RST 16   // "D"
-  #define RFM95_INT 15   // "B"
-
-#elif defined(ADAFRUIT_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ARDUINO_SAMD_FEATHER_M0)
- // Feather M0 w/Radio
-  #define RFM95_CS      8
-  #define RFM95_INT     3
-  #define RFM95_RST     4
+#elif defined(ESP8266)  // ESP8266 feather w/wing
+  #define RFM95_CS    2  // "E"
+  #define RFM95_INT  15  // "B"
+  #define RFM95_RST  16  // "D"
 
 #elif defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_NRF52840_FEATHER_SENSE)
-  #define RFM95_INT     9  // "A"
-  #define RFM95_CS      10  // "B"
-  #define RFM95_RST     11  // "C"
+  #define RFM95_CS   10  // "B"
+  #define RFM95_INT   9  // "A"
+  #define RFM95_RST  11  // "C"
 
-#elif defined(ESP32)  
-  /* ESP32 feather w/wing */
-  #define RFM95_RST     27   // "A"
-  #define RFM95_CS      33   // "B"
-  #define RFM95_INT     12   //  next to A
+#elif defined(ESP32)  // ESP32 feather w/wing
+  #define RFM95_CS   33  // "B"
+  #define RFM95_INT  27  // "A"
+  #define RFM95_RST  13
 
-#elif defined(ARDUINO_NRF52832_FEATHER)
-  /* nRF52832 feather w/wing */
-  #define RFM95_RST     7   // "A"
-  #define RFM95_CS      11   // "B"
-  #define RFM95_INT     31   // "C"
-  #define LED           17
-  
-#elif defined(TEENSYDUINO)
-  /* Teensy 3.x w/wing */
-  #define RFM95_RST     9   // "A"
-  #define RFM95_CS      10   // "B"
-  #define RFM95_INT     4    // "C"
+#elif defined(ARDUINO_NRF52832_FEATHER)  // nRF52832 feather w/wing
+  #define RFM95_CS   11  // "B"
+  #define RFM95_INT  31  // "C"
+  #define RFM95_RST   7  // "A"
+
 #endif
 
+/* Some other possible setups include:
+
+// Feather 32u4:
+#define RFM95_CS   8
+#define RFM95_RST  4
+#define RFM95_INT  7
+
+// Feather M0:
+#define RFM95_CS   8
+#define RFM95_RST  4
+#define RFM95_INT  3
+
+// Arduino shield:
+#define RFM95_CS  10
+#define RFM95_RST  9
+#define RFM95_INT  7
+
+// Feather 32u4 w/wing:
+#define RFM95_RST 11  // "A"
+#define RFM95_CS  10  // "B"
+#define RFM95_INT  2  // "SDA" (only SDA/SCL/RX/TX have IRQ!)
+
+// Feather m0 w/wing:
+#define RFM95_RST 11  // "A"
+#define RFM95_CS  10  // "B"
+#define RFM95_INT  6  // "D"
+*/
 
 // Change to 434.0 or other frequency, must match RX's freq!
 #define RF95_FREQ 915.0
@@ -83,19 +86,13 @@
 // Singleton instance of the radio driver
 RH_RF95 rf95(RFM95_CS, RFM95_INT);
 
-// Blinky on receipt
-#define LED 13
-
-void setup()
-{
-  pinMode(LED, OUTPUT);
+void setup() {
+  pinMode(LED_BUILTIN, OUTPUT);
   pinMode(RFM95_RST, OUTPUT);
   digitalWrite(RFM95_RST, HIGH);
 
   Serial.begin(115200);
-  while (!Serial) {
-    delay(1);
-  }
+  while (!Serial) delay(1);
   delay(100);
 
   Serial.println("Feather LoRa RX Test!");
@@ -128,17 +125,14 @@ void setup()
   rf95.setTxPower(23, false);
 }
 
-void loop()
-{
-  if (rf95.available())
-  {
+void loop() {
+  if (rf95.available()) {
     // Should be a message for us now
     uint8_t buf[RH_RF95_MAX_MESSAGE_LEN];
     uint8_t len = sizeof(buf);
 
-    if (rf95.recv(buf, &len))
-    {
-      digitalWrite(LED, HIGH);
+    if (rf95.recv(buf, &len)) {
+      digitalWrite(LED_BUILTIN, HIGH);
       RH_RF95::printBuffer("Received: ", buf, len);
       Serial.print("Got: ");
       Serial.println((char*)buf);
@@ -150,10 +144,8 @@ void loop()
       rf95.send(data, sizeof(data));
       rf95.waitPacketSent();
       Serial.println("Sent a reply");
-      digitalWrite(LED, LOW);
-    }
-    else
-    {
+      digitalWrite(LED_BUILTIN, LOW);
+    } else {
       Serial.println("Receive failed");
     }
   }

--- a/examples/feather/Feather9x_TX/Feather9x_TX.ino
+++ b/examples/feather/Feather9x_TX/Feather9x_TX.ino
@@ -9,71 +9,76 @@
 #include <SPI.h>
 #include <RH_RF95.h>
 
-/* for feather32u4 
-#define RFM95_CS 8
-#define RFM95_RST 4
-#define RFM95_INT 7
-*/
+// First 3 here are boards w/radio BUILT-IN. Boards using FeatherWing follow.
+#if defined (__AVR_ATmega32U4__)  // Feather 32u4 w/Radio
+  #define RFM95_CS    8
+  #define RFM95_INT   7
+  #define RFM95_RST   4
 
-/* for feather m0  
-#define RFM95_CS 8
-#define RFM95_RST 4
-#define RFM95_INT 3
-*/
+#elif defined(ADAFRUIT_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ARDUINO_SAMD_FEATHER_M0)  // Feather M0 w/Radio
+  #define RFM95_CS    8
+  #define RFM95_INT   3
+  #define RFM95_RST   4
 
-/* for shield 
-#define RFM95_CS 10
-#define RFM95_RST 9
-#define RFM95_INT 7
-*/
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040_RFM)  // Feather RP2040 w/Radio
+  #define RFM95_CS   16
+  #define RFM95_INT  21
+  #define RFM95_RST  17
 
-/* Feather 32u4 w/wing
-#define RFM95_RST     11   // "A"
-#define RFM95_CS      10   // "B"
-#define RFM95_INT     2    // "SDA" (only SDA/SCL/RX/TX have IRQ!)
-*/
+#elif defined (__AVR_ATmega328P__)  // Feather 328P w/wing
+  #define RFM95_CS    4  //
+  #define RFM95_INT   3  //
+  #define RFM95_RST   2  // "A"
 
-/* Feather m0 w/wing 
-#define RFM95_RST     11   // "A"
-#define RFM95_CS      10   // "B"
-#define RFM95_INT     6    // "D"
-*/
-
-#if defined(ESP8266)
-  /* for ESP w/featherwing */ 
-  #define RFM95_CS  2    // "E"
-  #define RFM95_RST 16   // "D"
-  #define RFM95_INT 15   // "B"
-
-#elif defined(ADAFRUIT_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ARDUINO_SAMD_FEATHER_M0)
-  // Feather M0 w/Radio
-  #define RFM95_CS      8
-  #define RFM95_INT     3
-  #define RFM95_RST     4
+#elif defined(ESP8266)  // ESP8266 feather w/wing
+  #define RFM95_CS    2  // "E"
+  #define RFM95_INT  15  // "B"
+  #define RFM95_RST  16  // "D"
 
 #elif defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_NRF52840_FEATHER_SENSE)
-  #define RFM95_INT     9  // "A"
-  #define RFM95_CS      10  // "B"
-  #define RFM95_RST     11  // "C"
-  
-#elif defined(ESP32)  
-  /* ESP32 feather w/wing */
-  #define RFM95_RST     27   // "A"
-  #define RFM95_CS      33   // "B"
-  #define RFM95_INT     12   //  next to A
+  #define RFM95_CS   10  // "B"
+  #define RFM95_INT   9  // "A"
+  #define RFM95_RST  11  // "C"
 
-#elif defined(ARDUINO_NRF52832_FEATHER)
-  /* nRF52832 feather w/wing */
-  #define RFM95_RST     7   // "A"
-  #define RFM95_CS      11   // "B"
-  #define RFM95_INT     31   // "C"
-  
-#elif defined(TEENSYDUINO)
-  /* Teensy 3.x w/wing */
-  #define RFM95_RST     9   // "A"
-  #define RFM95_CS      10   // "B"
-  #define RFM95_INT     4    // "C"
+#elif defined(ESP32)  // ESP32 feather w/wing
+  #define RFM95_CS   33  // "B"
+  #define RFM95_INT  27  // "A"
+  #define RFM95_RST  13
+
+#elif defined(ARDUINO_NRF52832_FEATHER)  // nRF52832 feather w/wing
+  #define RFM95_CS   11  // "B"
+  #define RFM95_INT  31  // "C"
+  #define RFM95_RST   7  // "A"
+
 #endif
+
+/* Some other possible setups include:
+
+// Feather 32u4:
+#define RFM95_CS   8
+#define RFM95_RST  4
+#define RFM95_INT  7
+
+// Feather M0:
+#define RFM95_CS   8
+#define RFM95_RST  4
+#define RFM95_INT  3
+
+// Arduino shield:
+#define RFM95_CS  10
+#define RFM95_RST  9
+#define RFM95_INT  7
+
+// Feather 32u4 w/wing:
+#define RFM95_RST 11  // "A"
+#define RFM95_CS  10  // "B"
+#define RFM95_INT  2  // "SDA" (only SDA/SCL/RX/TX have IRQ!)
+
+// Feather m0 w/wing:
+#define RFM95_RST 11  // "A"
+#define RFM95_CS  10  // "B"
+#define RFM95_INT  6  // "D"
+*/
 
 // Change to 434.0 or other frequency, must match RX's freq!
 #define RF95_FREQ 915.0
@@ -81,16 +86,12 @@
 // Singleton instance of the radio driver
 RH_RF95 rf95(RFM95_CS, RFM95_INT);
 
-void setup() 
-{
+void setup() {
   pinMode(RFM95_RST, OUTPUT);
   digitalWrite(RFM95_RST, HIGH);
 
   Serial.begin(115200);
-  while (!Serial) {
-    delay(1);
-  }
-
+  while (!Serial) delay(1);
   delay(100);
 
   Serial.println("Feather LoRa TX Test!");
@@ -114,32 +115,31 @@ void setup()
     while (1);
   }
   Serial.print("Set Freq to: "); Serial.println(RF95_FREQ);
-  
+
   // Defaults after init are 434.0MHz, 13dBm, Bw = 125 kHz, Cr = 4/5, Sf = 128chips/symbol, CRC on
 
   // The default transmitter power is 13dBm, using PA_BOOST.
-  // If you are using RFM95/96/97/98 modules which uses the PA_BOOST transmitter pin, then 
+  // If you are using RFM95/96/97/98 modules which uses the PA_BOOST transmitter pin, then
   // you can set transmitter powers from 5 to 23 dBm:
   rf95.setTxPower(23, false);
 }
 
 int16_t packetnum = 0;  // packet counter, we increment per xmission
 
-void loop()
-{
+void loop() {
   delay(1000); // Wait 1 second between transmits, could also 'sleep' here!
   Serial.println("Transmitting..."); // Send a message to rf95_server
-  
+
   char radiopacket[20] = "Hello World #      ";
   itoa(packetnum++, radiopacket+13, 10);
   Serial.print("Sending "); Serial.println(radiopacket);
   radiopacket[19] = 0;
-  
+
   Serial.println("Sending...");
   delay(10);
   rf95.send((uint8_t *)radiopacket, 20);
 
-  Serial.println("Waiting for packet to complete..."); 
+  Serial.println("Waiting for packet to complete...");
   delay(10);
   rf95.waitPacketSent();
   // Now wait for a reply
@@ -147,23 +147,17 @@ void loop()
   uint8_t len = sizeof(buf);
 
   Serial.println("Waiting for reply...");
-  if (rf95.waitAvailableTimeout(1000))
-  { 
-    // Should be a reply message for us now   
-    if (rf95.recv(buf, &len))
-   {
+  if (rf95.waitAvailableTimeout(1000)) {
+    // Should be a reply message for us now
+    if (rf95.recv(buf, &len)) {
       Serial.print("Got reply: ");
       Serial.println((char*)buf);
       Serial.print("RSSI: ");
-      Serial.println(rf95.lastRssi(), DEC);    
-    }
-    else
-    {
+      Serial.println(rf95.lastRssi(), DEC);
+    } else {
       Serial.println("Receive failed");
     }
-  }
-  else
-  {
+  } else {
     Serial.println("No reply, is there a listener around?");
   }
 

--- a/examples/feather/RadioHead69_AddrDemoTXRX_OLED/RadioHead69_AddrDemoTXRX_OLED.ino
+++ b/examples/feather/RadioHead69_AddrDemoTXRX_OLED/RadioHead69_AddrDemoTXRX_OLED.ino
@@ -26,7 +26,7 @@ Adafruit_SSD1306 oled = Adafruit_SSD1306();
   #define BUTTON_B 16
   #define BUTTON_C  2
   #define LED       0
-#elif defined(ESP32)
+#elif defined(ESP32) && !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2)
   #define BUTTON_A 15
   #define BUTTON_B 32
   #define BUTTON_C 14

--- a/examples/feather/RadioHead69_AddrDemoTXRX_OLED/RadioHead69_AddrDemoTXRX_OLED.ino
+++ b/examples/feather/RadioHead69_AddrDemoTXRX_OLED/RadioHead69_AddrDemoTXRX_OLED.ino
@@ -1,12 +1,9 @@
 // rf69 demo tx rx oled.pde
 // -*- mode: C++ -*-
-// Example sketch showing how to create a simple addressed, reliable messaging client
-// with the RH_RF69 class. RH_RF69 class does not provide for addressing or
-// reliability, so you should only use RH_RF69  if you do not need the higher
-// level messaging abilities.
-// It is designed to work with the other example rf69_server.
-// Demonstrates the use of AES encryption, setting the frequency and modem 
-// configuration
+// Example sketch showing how to create a simple addressed, reliable
+// messaging client with the RH_RF69 class.
+// Demonstrates the use of AES encryption, setting the frequency and modem
+// configuration.
 
 #include <SPI.h>
 #include <Wire.h>
@@ -16,19 +13,19 @@
 #include <Adafruit_SSD1306.h>
 
 // Where to send packets to!
-#define DEST_ADDRESS   1
+#define DEST_ADDRESS 1
 
 // change addresses for each client board, any number :)
-#define MY_ADDRESS     2
+#define MY_ADDRESS   2
 
 /************ OLED Setup ***************/
 Adafruit_SSD1306 oled = Adafruit_SSD1306();
 
 #if defined(ESP8266)
-  #define BUTTON_A 0
+  #define BUTTON_A  0
   #define BUTTON_B 16
-  #define BUTTON_C 2
-  #define LED      0
+  #define BUTTON_C  2
+  #define LED       0
 #elif defined(ESP32)
   #define BUTTON_A 15
   #define BUTTON_B 32
@@ -38,21 +35,26 @@ Adafruit_SSD1306 oled = Adafruit_SSD1306();
   #define BUTTON_A PA15
   #define BUTTON_B PC7
   #define BUTTON_C PC5
-  #define LED PB5
+  #define LED      PB5
 #elif defined(TEENSYDUINO)
-  #define BUTTON_A 4
-  #define BUTTON_B 3
-  #define BUTTON_C 8
-  #define LED 13
+  #define BUTTON_A  4
+  #define BUTTON_B  3
+  #define BUTTON_C  8
+  #define LED      13
 #elif defined(ARDUINO_NRF52832_FEATHER)
   #define BUTTON_A 31
   #define BUTTON_B 30
   #define BUTTON_C 27
-  #define LED 17
-#else // 32u4, M0, and 328p
-  #define BUTTON_A 9
-  #define BUTTON_B 6
-  #define BUTTON_C 5
+  #define LED      17
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040_RFM)
+  #define BUTTON_A  9
+  #define BUTTON_B  6
+  #define BUTTON_C  5
+  #define LED      LED_BUILTIN
+#else  // 32u4, M0, and 328p
+  #define BUTTON_A  9
+  #define BUTTON_B  6
+  #define BUTTON_C  5
   #define LED      13
 #endif
 
@@ -62,40 +64,55 @@ Adafruit_SSD1306 oled = Adafruit_SSD1306();
 // Change to 434.0 or other frequency, must match RX's freq!
 #define RF69_FREQ 915.0
 
-#if defined (__AVR_ATmega32U4__) // Feather 32u4 w/Radio
-  #define RFM69_CS      8
-  #define RFM69_INT     7
-  #define RFM69_RST     4
-#endif
+// First 3 here are boards w/radio BUILT-IN. Boards using FeatherWing follow.
+#if defined (__AVR_ATmega32U4__)  // Feather 32u4 w/Radio
+  #define RFM69_CS    8
+  #define RFM69_INT   7
+  #define RFM69_RST   4
+  #define LED        13
 
-#if defined(ARDUINO_SAMD_FEATHER_M0) // Feather M0 w/Radio
-  #define RFM69_CS      8
-  #define RFM69_INT     3
-  #define RFM69_RST     4
-#endif
+#elif defined(ADAFRUIT_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ARDUINO_SAMD_FEATHER_M0)  // Feather M0 w/Radio
+  #define RFM69_CS    8
+  #define RFM69_INT   3
+  #define RFM69_RST   4
+  #define LED        13
 
-#if defined (__AVR_ATmega328P__)  // Feather 328P w/wing
-  #define RFM69_INT     3  // 
-  #define RFM69_CS      4  //
-  #define RFM69_RST     2  // "A"
-#endif
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040_RFM)  // Feather RP2040 w/Radio
+  #define RFM69_CS   16
+  #define RFM69_INT  21
+  #define RFM69_RST  17
+  #define LED        LED_BUILTIN
 
-#if defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_NRF52840_FEATHER_SENSE)
-  #define RFM69_INT     9  // "A"
-  #define RFM69_CS      10  // "B"
-  #define RFM69_RST     11  // "C"
+#elif defined (__AVR_ATmega328P__)  // Feather 328P w/wing
+  #define RFM69_CS    4  //
+  #define RFM69_INT   3  //
+  #define RFM69_RST   2  // "A"
+  #define LED        13
 
-#elif defined(ESP32)    // ESP32 feather w/wing
-  #define RFM69_RST     13   // same as LED
-  #define RFM69_CS      33   // "B"
-  #define RFM69_INT     27   // "A"
-#endif
+#elif defined(ESP8266)  // ESP8266 feather w/wing
+  #define RFM69_CS    2  // "E"
+  #define RFM69_INT  15  // "B"
+  #define RFM69_RST  16  // "D"
+  #define LED         0
 
-#if defined(ARDUINO_NRF52832_FEATHER)
-  /* nRF52832 feather w/wing */
-  #define RFM69_RST     7   // "A"
-  #define RFM69_CS      11   // "B"
-  #define RFM69_INT     31   // "C"
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_NRF52840_FEATHER_SENSE)
+  #define RFM69_CS   10  // "B"
+  #define RFM69_INT   9  // "A"
+  #define RFM69_RST  11  // "C"
+  #define LED        13
+
+#elif defined(ESP32)  // ESP32 feather w/wing
+  #define RFM69_CS   33  // "B"
+  #define RFM69_INT  27  // "A"
+  #define RFM69_RST  13  // same as LED
+  #define LED        13
+
+#elif defined(ARDUINO_NRF52832_FEATHER)  // nRF52832 feather w/wing
+  #define RFM69_CS   11  // "B"
+  #define RFM69_INT  31  // "C"
+  #define RFM69_RST   7  // "A"
+  #define LED        17
+
 #endif
 
 // Singleton instance of the radio driver
@@ -104,11 +121,10 @@ RH_RF69 rf69(RFM69_CS, RFM69_INT);
 // Class to manage message delivery and receipt, using the driver declared above
 RHReliableDatagram rf69_manager(rf69, MY_ADDRESS);
 
-void setup() 
-{
+void setup() {
   delay(500);
   Serial.begin(115200);
-  //while (!Serial) { delay(1); } // wait until serial console is open, remove if not tethered to computer
+  //while (!Serial) delay(1); // Wait for Serial Console (comment out line if no computer)
 
   // Initialize OLED display
   oled.begin(SSD1306_SWITCHCAPVCC, 0x3C);  // initialize with the I2C addr 0x3C (for the 128x32)
@@ -121,7 +137,7 @@ void setup()
   pinMode(BUTTON_B, INPUT_PULLUP);
   pinMode(BUTTON_C, INPUT_PULLUP);
 
-  pinMode(LED, OUTPUT);     
+  pinMode(LED, OUTPUT);
   pinMode(RFM69_RST, OUTPUT);
   digitalWrite(RFM69_RST, LOW);
 
@@ -132,13 +148,13 @@ void setup()
   delay(10);
   digitalWrite(RFM69_RST, LOW);
   delay(10);
-  
+
   if (!rf69_manager.init()) {
     Serial.println("RFM69 radio init failed");
     while (1);
   }
   Serial.println("RFM69 radio init OK!");
-  
+
   // Defaults after init are 434.0MHz, modulation GFSK_Rb250Fd250, +13dbM (for low power module)
   // No encryption
   if (!rf69.setFrequency(RF69_FREQ)) {
@@ -148,8 +164,6 @@ void setup()
   // If you are using a high power RF69 eg RFM69HW, you *must* set a Tx power with the
   // ishighpowermodule flag set like this:
   rf69.setTxPower(14, true);
-  
-  pinMode(LED, OUTPUT);
 
   Serial.print("RFM69 radio @");  Serial.print((int)RF69_FREQ);  Serial.println(" MHz");
 
@@ -169,8 +183,7 @@ void setup()
 uint8_t buf[RH_RF69_MAX_MESSAGE_LEN];
 uint8_t data[] = "  OK";
 
-void loop()
-{  
+void loop() {
    if (rf69_manager.available()) {
     // Wait for a message addressed to us from the client
     uint8_t len = sizeof(buf);
@@ -184,18 +197,18 @@ void loop()
       Serial.println((char*)buf);
       Serial.print("RSSI: "); Serial.println(rf69.lastRssi(), DEC);
 
-      // echo last button       
+      // echo last button
       data[0] = buf[8];
       // Send a reply back to the originator client
       if (!rf69_manager.sendtoWait(data, sizeof(data), from))
         Serial.println("sendtoWait failed");
-    
+
       digitalWrite(LED, HIGH);
       oled.clearDisplay();
       oled.setCursor(0,0);
       oled.println((char*)buf);
       oled.print("RSSI: "); oled.print(rf69.lastRssi());
-      oled.display(); 
+      oled.display();
       digitalWrite(LED, LOW);
     }
   }
@@ -203,7 +216,7 @@ void loop()
   if (!digitalRead(BUTTON_A) || !digitalRead(BUTTON_B) || !digitalRead(BUTTON_C))
   {
     Serial.println("Button pressed!");
-    
+
     char radiopacket[20] = "Button #";
     if (!digitalRead(BUTTON_A)) radiopacket[8] = 'A';
     if (!digitalRead(BUTTON_B)) radiopacket[8] = 'B';
@@ -215,7 +228,7 @@ void loop()
     if (rf69_manager.sendtoWait((uint8_t *)radiopacket, strlen(radiopacket), DEST_ADDRESS)) {
       // Now wait for a reply from the server
       uint8_t len = sizeof(buf);
-      uint8_t from;   
+      uint8_t from;
       if (rf69_manager.recvfromAckTimeout(buf, &len, 2000, &from)) {
         buf[len] = 0;
         Serial.print("Got reply from #");
@@ -226,8 +239,8 @@ void loop()
         oled.setCursor(0,0);
         oled.print("Reply:"); oled.println((char*)buf);
         oled.print("RSSI: "); oled.print(rf69.lastRssi());
-        oled.display(); 
-        
+        oled.display();
+
       } else {
         Serial.println("No reply, is anyone listening?");
       }
@@ -236,4 +249,3 @@ void loop()
     }
   }
 }
-

--- a/examples/feather/RadioHead69_AddrDemo_RX/RadioHead69_AddrDemo_RX.ino
+++ b/examples/feather/RadioHead69_AddrDemo_RX/RadioHead69_AddrDemo_RX.ino
@@ -1,12 +1,10 @@
 // rf69 demo tx rx.pde
 // -*- mode: C++ -*-
-// Example sketch showing how to create a simple addressed, reliable messaging client
-// with the RH_RF69 class. RH_RF69 class does not provide for addressing or
-// reliability, so you should only use RH_RF69  if you do not need the higher
-// level messaging abilities.
-// It is designed to work with the other example rf69_server.
-// Demonstrates the use of AES encryption, setting the frequency and modem 
-// configuration
+// Example sketch showing how to create a simple addressed, reliable
+// messaging client with the RH_RF69 class.
+// It is designed to work with the other example RadioHead69_AddrDemo_TX.
+// Demonstrates the use of AES encryption, setting the frequency and
+// modem configuration.
 
 #include <SPI.h>
 #include <RH_RF69.h>
@@ -17,72 +15,72 @@
 // Change to 434.0 or other frequency, must match RX's freq!
 #define RF69_FREQ 915.0
 
-// who am i? (server address)
-#define MY_ADDRESS     1
+// Who am i? (client address)
+#define MY_ADDRESS   2
 
+// First 3 here are boards w/radio BUILT-IN. Boards using FeatherWing follow.
+#if defined (__AVR_ATmega32U4__)  // Feather 32u4 w/Radio
+  #define RFM69_CS    8
+  #define RFM69_INT   7
+  #define RFM69_RST   4
+  #define LED        13
 
-#if defined (__AVR_ATmega32U4__) // Feather 32u4 w/Radio
-  #define RFM69_CS      8
-  #define RFM69_INT     7
-  #define RFM69_RST     4
-  #define LED           13
-#endif
+#elif defined(ADAFRUIT_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ARDUINO_SAMD_FEATHER_M0)  // Feather M0 w/Radio
+  #define RFM69_CS    8
+  #define RFM69_INT   3
+  #define RFM69_RST   4
+  #define LED        13
 
-#if defined(ADAFRUIT_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ARDUINO_SAMD_FEATHER_M0)
-  // Feather M0 w/Radio
-  #define RFM69_CS      8
-  #define RFM69_INT     3
-  #define RFM69_RST     4
-  #define LED           13
-#endif
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040_RFM)  // Feather RP2040 w/Radio
+  #define RFM69_CS   16
+  #define RFM69_INT  21
+  #define RFM69_RST  17
+  #define LED        LED_BUILTIN
 
-#if defined (__AVR_ATmega328P__)  // Feather 328P w/wing
-  #define RFM69_INT     3  // 
-  #define RFM69_CS      4  //
-  #define RFM69_RST     2  // "A"
-  #define LED           13
-#endif
+#elif defined (__AVR_ATmega328P__)  // Feather 328P w/wing
+  #define RFM69_CS    4  //
+  #define RFM69_INT   3  //
+  #define RFM69_RST   2  // "A"
+  #define LED        13
 
-#if defined(ESP8266)    // ESP8266 feather w/wing
-  #define RFM69_CS      2    // "E"
-  #define RFM69_IRQ     15   // "B"
-  #define RFM69_RST     16   // "D"
-  #define LED           0
-#endif
+#elif defined(ESP8266)  // ESP8266 feather w/wing
+  #define RFM69_CS    2  // "E"
+  #define RFM69_INT  15  // "B"
+  #define RFM69_RST  16  // "D"
+  #define LED         0
 
-#if defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_NRF52840_FEATHER_SENSE)
-  #define RFM69_INT     9  // "A"
-  #define RFM69_CS      10  // "B"
-  #define RFM69_RST     11  // "C"
-  #define LED           13
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_NRF52840_FEATHER_SENSE)
+  #define RFM69_CS   10  // "B"
+  #define RFM69_INT   9  // "A"
+  #define RFM69_RST  11  // "C"
+  #define LED        13
 
-#elif defined(ESP32)    // ESP32 feather w/wing
-  #define RFM69_RST     13   // same as LED
-  #define RFM69_CS      33   // "B"
-  #define RFM69_INT     27   // "A"
-  #define LED           13
-#endif
+#elif defined(ESP32)  // ESP32 feather w/wing
+  #define RFM69_CS   33  // "B"
+  #define RFM69_INT  27  // "A"
+  #define RFM69_RST  13  // same as LED
+  #define LED        13
 
-#if defined(ARDUINO_NRF52832_FEATHER)
-  /* nRF52832 feather w/wing */
-  #define RFM69_RST     7   // "A"
-  #define RFM69_CS      11   // "B"
-  #define RFM69_INT     31   // "C"
-  #define LED           17
+#elif defined(ARDUINO_NRF52832_FEATHER)  // nRF52832 feather w/wing
+  #define RFM69_CS   11  // "B"
+  #define RFM69_INT  31  // "C"
+  #define RFM69_RST   7  // "A"
+  #define LED        17
+
 #endif
 
 /* Teensy 3.x w/wing
-#define RFM69_RST     9   // "A"
-#define RFM69_CS      10   // "B"
-#define RFM69_IRQ     4    // "C"
-#define RFM69_IRQN    digitalPinToInterrupt(RFM69_IRQ )
+#define RFM69_CS     10  // "B"
+#define RFM69_INT     4  // "C"
+#define RFM69_RST     9  // "A"
+#define RFM69_IRQN   digitalPinToInterrupt(RFM69_INT)
 */
- 
-/* WICED Feather w/wing 
-#define RFM69_RST     PA4     // "A"
-#define RFM69_CS      PB4     // "B"
-#define RFM69_IRQ     PA15    // "C"
-#define RFM69_IRQN    RFM69_IRQ
+
+/* WICED Feather w/wing
+#define RFM69_CS     PB4  // "B"
+#define RFM69_INT    PA15 // "C"
+#define RFM69_RST    PA4  // "A"
+#define RFM69_IRQN   RFM69_INT
 */
 
 // Singleton instance of the radio driver
@@ -91,15 +89,11 @@ RH_RF69 rf69(RFM69_CS, RFM69_INT);
 // Class to manage message delivery and receipt, using the driver declared above
 RHReliableDatagram rf69_manager(rf69, MY_ADDRESS);
 
-
-int16_t packetnum = 0;  // packet counter, we increment per xmission
-
-void setup() 
-{
+void setup() {
   Serial.begin(115200);
-  //while (!Serial) { delay(1); } // wait until serial console is open, remove if not tethered to computer
+  //while (!Serial) delay(1); // Wait for Serial Console (comment out line if no computer)
 
-  pinMode(LED, OUTPUT);     
+  pinMode(LED, OUTPUT);
   pinMode(RFM69_RST, OUTPUT);
   digitalWrite(RFM69_RST, LOW);
 
@@ -111,7 +105,7 @@ void setup()
   delay(10);
   digitalWrite(RFM69_RST, LOW);
   delay(10);
-  
+
   if (!rf69_manager.init()) {
     Serial.println("RFM69 radio init failed");
     while (1);
@@ -129,14 +123,11 @@ void setup()
 
   // The encryption key has to be the same as the one in the server
   uint8_t key[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-                    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+                    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
   rf69.setEncryptionKey(key);
-  
-  pinMode(LED, OUTPUT);
 
   Serial.print("RFM69 radio @");  Serial.print((int)RF69_FREQ);  Serial.println(" MHz");
 }
-
 
 // Dont put this on the stack:
 uint8_t data[] = "And hello back to you";
@@ -144,20 +135,19 @@ uint8_t data[] = "And hello back to you";
 uint8_t buf[RH_RF69_MAX_MESSAGE_LEN];
 
 void loop() {
-  if (rf69_manager.available())
-  {
+  if (rf69_manager.available()) {
     // Wait for a message addressed to us from the client
     uint8_t len = sizeof(buf);
     uint8_t from;
     if (rf69_manager.recvfromAck(buf, &len, &from)) {
       buf[len] = 0; // zero out remaining string
-      
+
       Serial.print("Got packet from #"); Serial.print(from);
       Serial.print(" [RSSI :");
       Serial.print(rf69.lastRssi());
       Serial.print("] : ");
       Serial.println((char*)buf);
-      Blink(LED, 40, 3); //blink LED 3 times, 40ms between blinks
+      Blink(LED, 40, 3); // blink LED 3 times, 40ms between blinks
 
       // Send a reply back to the originator client
       if (!rf69_manager.sendtoWait(data, sizeof(data), from))
@@ -166,12 +156,11 @@ void loop() {
   }
 }
 
-
-void Blink(byte PIN, byte DELAY_MS, byte loops) {
-  for (byte i=0; i<loops; i++)  {
-    digitalWrite(PIN,HIGH);
-    delay(DELAY_MS);
-    digitalWrite(PIN,LOW);
-    delay(DELAY_MS);
+void Blink(byte pin, byte delay_ms, byte loops) {
+  while (loops--) {
+    digitalWrite(pin, HIGH);
+    delay(delay_ms);
+    digitalWrite(pin, LOW);
+    delay(delay_ms);
   }
 }

--- a/examples/feather/RadioHead69_AddrDemo_TX/RadioHead69_AddrDemo_TX.ino
+++ b/examples/feather/RadioHead69_AddrDemo_TX/RadioHead69_AddrDemo_TX.ino
@@ -1,89 +1,89 @@
 // rf69 demo tx rx.pde
 // -*- mode: C++ -*-
-// Example sketch showing how to create a simple addressed, reliable messaging client
-// with the RH_RF69 class. RH_RF69 class does not provide for addressing or
-// reliability, so you should only use RH_RF69  if you do not need the higher
-// level messaging abilities.
-// It is designed to work with the other example rf69_server.
-// Demonstrates the use of AES encryption, setting the frequency and modem 
-// configuration
+// Example sketch showing how to create a simple addressed, reliable
+// messaging client with the RH_RF69 class.
+// It is designed to work with the other example RadioHead69_AddrDemo_RX.
+// Demonstrates the use of AES encryption, setting the frequency and
+// modem configuration.
 
 #include <SPI.h>
 #include <RH_RF69.h>
 #include <RHReliableDatagram.h>
+
 /************ Radio Setup ***************/
 
 // Change to 434.0 or other frequency, must match RX's freq!
 #define RF69_FREQ 915.0
 
-// Where to send packets to!
-#define DEST_ADDRESS   1
-// change addresses for each client board, any number :)
-#define MY_ADDRESS     2
+// Who am i? (server address)
+#define MY_ADDRESS   1
 
+// Where to send packets to! MY_ADDRESS in client (RX) should match this.
+#define DEST_ADDRESS 2
 
-#if defined (__AVR_ATmega32U4__) // Feather 32u4 w/Radio
-  #define RFM69_CS      8
-  #define RFM69_INT     7
-  #define RFM69_RST     4
-  #define LED           13
-#endif
+// First 3 here are boards w/radio BUILT-IN. Boards using FeatherWing follow.
+#if defined (__AVR_ATmega32U4__)  // Feather 32u4 w/Radio
+  #define RFM69_CS    8
+  #define RFM69_INT   7
+  #define RFM69_RST   4
+  #define LED        13
 
-#if defined(ADAFRUIT_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ARDUINO_SAMD_FEATHER_M0)
-  // Feather M0 w/Radio
-  #define RFM69_CS      8
-  #define RFM69_INT     3
-  #define RFM69_RST     4
-  #define LED           13
-#endif
+#elif defined(ADAFRUIT_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ARDUINO_SAMD_FEATHER_M0)  // Feather M0 w/Radio
+  #define RFM69_CS    8
+  #define RFM69_INT   3
+  #define RFM69_RST   4
+  #define LED        13
 
-#if defined (__AVR_ATmega328P__)  // Feather 328P w/wing
-  #define RFM69_INT     3  // 
-  #define RFM69_CS      4  //
-  #define RFM69_RST     2  // "A"
-  #define LED           13
-#endif
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040_RFM)  // Feather RP2040 w/Radio
+  #define RFM69_CS   16
+  #define RFM69_INT  21
+  #define RFM69_RST  17
+  #define LED        LED_BUILTIN
 
-#if defined(ESP8266)    // ESP8266 feather w/wing
-  #define RFM69_CS      2    // "E"
-  #define RFM69_IRQ     15   // "B"
-  #define RFM69_RST     16   // "D"
-  #define LED           0
-#endif
+#elif defined (__AVR_ATmega328P__)  // Feather 328P w/wing
+  #define RFM69_CS    4  //
+  #define RFM69_INT   3  //
+  #define RFM69_RST   2  // "A"
+  #define LED        13
 
-#if defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_NRF52840_FEATHER_SENSE)
-  #define RFM69_INT     9  // "A"
-  #define RFM69_CS      10  // "B"
-  #define RFM69_RST     11  // "C"
-  #define LED           13
+#elif defined(ESP8266)  // ESP8266 feather w/wing
+  #define RFM69_CS    2  // "E"
+  #define RFM69_INT  15  // "B"
+  #define RFM69_RST  16  // "D"
+  #define LED         0
 
-#elif defined(ESP32)    // ESP32 feather w/wing
-  #define RFM69_RST     13   // same as LED
-  #define RFM69_CS      33   // "B"
-  #define RFM69_INT     27   // "A"
-  #define LED           13
-#endif
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_NRF52840_FEATHER_SENSE)
+  #define RFM69_CS   10  // "B"
+  #define RFM69_INT   9  // "A"
+  #define RFM69_RST  11  // "C"
+  #define LED        13
 
-#if defined(ARDUINO_NRF52832_FEATHER)
-  /* nRF52832 feather w/wing */
-  #define RFM69_RST     7   // "A"
-  #define RFM69_CS      11   // "B"
-  #define RFM69_INT     31   // "C"
-  #define LED           17
+#elif defined(ESP32)  // ESP32 feather w/wing
+  #define RFM69_CS   33  // "B"
+  #define RFM69_INT  27  // "A"
+  #define RFM69_RST  13  // same as LED
+  #define LED        13
+
+#elif defined(ARDUINO_NRF52832_FEATHER)  // nRF52832 feather w/wing
+  #define RFM69_CS   11  // "B"
+  #define RFM69_INT  31  // "C"
+  #define RFM69_RST   7  // "A"
+  #define LED        17
+
 #endif
 
 /* Teensy 3.x w/wing
-#define RFM69_RST     9   // "A"
-#define RFM69_CS      10   // "B"
-#define RFM69_IRQ     4    // "C"
-#define RFM69_IRQN    digitalPinToInterrupt(RFM69_IRQ )
+#define RFM69_CS     10  // "B"
+#define RFM69_INT     4  // "C"
+#define RFM69_RST     9  // "A"
+#define RFM69_IRQN   digitalPinToInterrupt(RFM69_INT)
 */
- 
-/* WICED Feather w/wing 
-#define RFM69_RST     PA4     // "A"
-#define RFM69_CS      PB4     // "B"
-#define RFM69_IRQ     PA15    // "C"
-#define RFM69_IRQN    RFM69_IRQ
+
+/* WICED Feather w/wing
+#define RFM69_CS     PB4  // "B"
+#define RFM69_INT    PA15 // "C"
+#define RFM69_RST    PA4  // "A"
+#define RFM69_IRQN   RFM69_INT
 */
 
 // Singleton instance of the radio driver
@@ -92,15 +92,13 @@ RH_RF69 rf69(RFM69_CS, RFM69_INT);
 // Class to manage message delivery and receipt, using the driver declared above
 RHReliableDatagram rf69_manager(rf69, MY_ADDRESS);
 
-
 int16_t packetnum = 0;  // packet counter, we increment per xmission
 
-void setup() 
-{
+void setup() {
   Serial.begin(115200);
-  //while (!Serial) { delay(1); } // wait until serial console is open, remove if not tethered to computer
+  //while (!Serial) delay(1); // Wait for Serial Console (comment out line if no computer)
 
-  pinMode(LED, OUTPUT);     
+  pinMode(LED, OUTPUT);
   pinMode(RFM69_RST, OUTPUT);
   digitalWrite(RFM69_RST, LOW);
 
@@ -112,7 +110,7 @@ void setup()
   delay(10);
   digitalWrite(RFM69_RST, LOW);
   delay(10);
-  
+
   if (!rf69_manager.init()) {
     Serial.println("RFM69 radio init failed");
     while (1);
@@ -128,16 +126,13 @@ void setup()
   // ishighpowermodule flag set like this:
   rf69.setTxPower(20, true);  // range from 14-20 for power, 2nd arg must be true for 69HCW
 
-  // The encryption key has to be the same as the one in the server
+  // The encryption key has to be the same as the one in the client
   uint8_t key[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-                    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+                    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
   rf69.setEncryptionKey(key);
-  
-  pinMode(LED, OUTPUT);
 
   Serial.print("RFM69 radio @");  Serial.print((int)RF69_FREQ);  Serial.println(" MHz");
 }
-
 
 // Dont put this on the stack:
 uint8_t buf[RH_RF69_MAX_MESSAGE_LEN];
@@ -149,21 +144,21 @@ void loop() {
   char radiopacket[20] = "Hello World #";
   itoa(packetnum++, radiopacket+13, 10);
   Serial.print("Sending "); Serial.println(radiopacket);
-  
+
   // Send a message to the DESTINATION!
   if (rf69_manager.sendtoWait((uint8_t *)radiopacket, strlen(radiopacket), DEST_ADDRESS)) {
     // Now wait for a reply from the server
     uint8_t len = sizeof(buf);
-    uint8_t from;   
+    uint8_t from;
     if (rf69_manager.recvfromAckTimeout(buf, &len, 2000, &from)) {
       buf[len] = 0; // zero out remaining string
-      
+
       Serial.print("Got reply from #"); Serial.print(from);
       Serial.print(" [RSSI :");
       Serial.print(rf69.lastRssi());
       Serial.print("] : ");
-      Serial.println((char*)buf);     
-      Blink(LED, 40, 3); //blink LED 3 times, 40ms between blinks
+      Serial.println((char*)buf);
+      Blink(LED, 40, 3); // blink LED 3 times, 40ms between blinks
     } else {
       Serial.println("No reply, is anyone listening?");
     }
@@ -172,11 +167,11 @@ void loop() {
   }
 }
 
-void Blink(byte PIN, byte DELAY_MS, byte loops) {
-  for (byte i=0; i<loops; i++)  {
-    digitalWrite(PIN,HIGH);
-    delay(DELAY_MS);
-    digitalWrite(PIN,LOW);
-    delay(DELAY_MS);
+void Blink(byte pin, byte delay_ms, byte loops) {
+  while (loops--) {
+    digitalWrite(pin, HIGH);
+    delay(delay_ms);
+    digitalWrite(pin, LOW);
+    delay(delay_ms);
   }
 }

--- a/examples/feather/RadioHead69_RawDemoTXRX_OLED/RadioHead69_RawDemoTXRX_OLED.ino
+++ b/examples/feather/RadioHead69_RawDemoTXRX_OLED/RadioHead69_RawDemoTXRX_OLED.ino
@@ -176,7 +176,6 @@ void setup() {
   delay(500);
 }
 
-
 void loop() {
   if (rf69.waitAvailableTimeout(100)) {
     // Should be a message for us now

--- a/examples/feather/RadioHead69_RawDemoTXRX_OLED/RadioHead69_RawDemoTXRX_OLED.ino
+++ b/examples/feather/RadioHead69_RawDemoTXRX_OLED/RadioHead69_RawDemoTXRX_OLED.ino
@@ -22,7 +22,7 @@ Adafruit_SSD1306 oled = Adafruit_SSD1306();
   #define BUTTON_B 16
   #define BUTTON_C  2
   #define LED       0
-#elif defined(ESP32)
+#elif defined(ESP32) && !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2)
   #define BUTTON_A 15
   #define BUTTON_B 32
   #define BUTTON_C 14

--- a/examples/feather/RadioHead69_RawDemoTXRX_OLED/RadioHead69_RawDemoTXRX_OLED.ino
+++ b/examples/feather/RadioHead69_RawDemoTXRX_OLED/RadioHead69_RawDemoTXRX_OLED.ino
@@ -1,12 +1,11 @@
 // rf69 demo tx rx oled.pde
 // -*- mode: C++ -*-
 // Example sketch showing how to create a simple messageing client
-// with the RH_RF69 class. RH_RF69 class does not provide for addressing or
-// reliability, so you should only use RH_RF69  if you do not need the higher
-// level messaging abilities.
-// It is designed to work with the other example rf69_server.
-// Demonstrates the use of AES encryption, setting the frequency and modem 
-// configuration
+// with the RH_RF69 class. RH_RF69 class does not provide for addressing
+// or reliability, so you should only use RH_RF69 if you do not need the
+// higher level messaging abilities.
+// Demonstrates the use of AES encryption, setting the frequency and modem
+// configuration.
 
 #include <SPI.h>
 #include <RH_RF69.h>
@@ -15,13 +14,14 @@
 #include <Adafruit_SSD1306.h>
 
 /************ OLED Setup ***************/
+
 Adafruit_SSD1306 oled = Adafruit_SSD1306();
 
 #if defined(ESP8266)
-  #define BUTTON_A 0
+  #define BUTTON_A  0
   #define BUTTON_B 16
-  #define BUTTON_C 2
-  #define LED      0
+  #define BUTTON_C  2
+  #define LED       0
 #elif defined(ESP32)
   #define BUTTON_A 15
   #define BUTTON_B 32
@@ -31,76 +31,92 @@ Adafruit_SSD1306 oled = Adafruit_SSD1306();
   #define BUTTON_A PA15
   #define BUTTON_B PC7
   #define BUTTON_C PC5
-  #define LED PB5
+  #define LED      PB5
 #elif defined(TEENSYDUINO)
-  #define BUTTON_A 4
-  #define BUTTON_B 3
-  #define BUTTON_C 8
-  #define LED 13
+  #define BUTTON_A  4
+  #define BUTTON_B  3
+  #define BUTTON_C  8
+  #define LED      13
 #elif defined(ARDUINO_NRF52832_FEATHER)
   #define BUTTON_A 31
   #define BUTTON_B 30
   #define BUTTON_C 27
-  #define LED 17
-#else // 32u4, M0, and 328p
-  #define BUTTON_A 9
-  #define BUTTON_B 6
-  #define BUTTON_C 5
+  #define LED      17
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040_RFM)
+  #define BUTTON_A  9
+  #define BUTTON_B  6
+  #define BUTTON_C  5
+  #define LED      LED_BUILTIN
+#else  // 32u4, M0, and 328p
+  #define BUTTON_A  9
+  #define BUTTON_B  6
+  #define BUTTON_C  5
   #define LED      13
 #endif
-
 
 /************ Radio Setup ***************/
 
 // Change to 434.0 or other frequency, must match RX's freq!
 #define RF69_FREQ 915.0
 
-#if defined (__AVR_ATmega32U4__) // Feather 32u4 w/Radio
-  #define RFM69_CS      8
-  #define RFM69_INT     7
-  #define RFM69_RST     4
-#endif
+// First 3 here are boards w/radio BUILT-IN. Boards using FeatherWing follow.
+#if defined (__AVR_ATmega32U4__)  // Feather 32u4 w/Radio
+  #define RFM69_CS    8
+  #define RFM69_INT   7
+  #define RFM69_RST   4
+  #define LED        13
 
-#if defined(ARDUINO_SAMD_FEATHER_M0) // Feather M0 w/Radio
-  #define RFM69_CS      8
-  #define RFM69_INT     3
-  #define RFM69_RST     4
-#endif
+#elif defined(ADAFRUIT_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ARDUINO_SAMD_FEATHER_M0)  // Feather M0 w/Radio
+  #define RFM69_CS    8
+  #define RFM69_INT   3
+  #define RFM69_RST   4
+  #define LED        13
 
-#if defined (__AVR_ATmega328P__)  // Feather 328P w/wing
-  #define RFM69_INT     3  // 
-  #define RFM69_CS      4  //
-  #define RFM69_RST     2  // "A"
-#endif
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040_RFM)  // Feather RP2040 w/Radio
+  #define RFM69_CS   16
+  #define RFM69_INT  21
+  #define RFM69_RST  17
+  #define LED        LED_BUILTIN
 
-#if defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_NRF52840_FEATHER_SENSE)
-  #define RFM69_INT     9  // "A"
-  #define RFM69_CS      10  // "B"
-  #define RFM69_RST     11  // "C"
-  #define LED           13
+#elif defined (__AVR_ATmega328P__)  // Feather 328P w/wing
+  #define RFM69_CS    4  //
+  #define RFM69_INT   3  //
+  #define RFM69_RST   2  // "A"
+  #define LED        13
 
-#elif defined(ESP32)    // ESP32 feather w/wing
-  #define RFM69_RST     13   // same as LED
-  #define RFM69_CS      33   // "B"
-  #define RFM69_INT     27   // "A"
-#endif
+#elif defined(ESP8266)  // ESP8266 feather w/wing
+  #define RFM69_CS    2  // "E"
+  #define RFM69_INT  15  // "B"
+  #define RFM69_RST  16  // "D"
+  #define LED         0
 
-#if defined(ARDUINO_NRF52832_FEATHER)
-  /* nRF52832 feather w/wing */
-  #define RFM69_RST     7   // "A"
-  #define RFM69_CS      11   // "B"
-  #define RFM69_INT     31   // "C"
-  #define LED           17
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_NRF52840_FEATHER_SENSE)
+  #define RFM69_CS   10  // "B"
+  #define RFM69_INT   9  // "A"
+  #define RFM69_RST  11  // "C"
+  #define LED        13
+
+#elif defined(ESP32)  // ESP32 feather w/wing
+  #define RFM69_CS   33  // "B"
+  #define RFM69_INT  27  // "A"
+  #define RFM69_RST  13  // same as LED
+  #define LED        13
+
+#elif defined(ARDUINO_NRF52832_FEATHER)  // nRF52832 feather w/wing
+  #define RFM69_CS   11  // "B"
+  #define RFM69_INT  31  // "C"
+  #define RFM69_RST   7  // "A"
+  #define LED        17
+
 #endif
 
 // Singleton instance of the radio driver
 RH_RF69 rf69(RFM69_CS, RFM69_INT);
 
-void setup() 
-{
+void setup() {
   delay(500);
   Serial.begin(115200);
-  //while (!Serial) { delay(1); } // wait until serial console is open, remove if not tethered to computer
+  //while (!Serial) delay(1); // Wait for Serial Console (comment out line if no computer)
 
   // Initialize OLED display
   oled.begin(SSD1306_SWITCHCAPVCC, 0x3C);  // initialize with the I2C addr 0x3C (for the 128x32)
@@ -113,7 +129,7 @@ void setup()
   pinMode(BUTTON_B, INPUT_PULLUP);
   pinMode(BUTTON_C, INPUT_PULLUP);
 
-  pinMode(LED, OUTPUT);     
+  pinMode(LED, OUTPUT);
   pinMode(RFM69_RST, OUTPUT);
   digitalWrite(RFM69_RST, LOW);
 
@@ -124,13 +140,13 @@ void setup()
   delay(10);
   digitalWrite(RFM69_RST, LOW);
   delay(10);
-  
+
   if (!rf69.init()) {
     Serial.println("RFM69 radio init failed");
     while (1);
   }
   Serial.println("RFM69 radio init OK!");
-  
+
   // Defaults after init are 434.0MHz, modulation GFSK_Rb250Fd250, +13dbM (for low power module)
   // No encryption
   if (!rf69.setFrequency(RF69_FREQ)) {
@@ -145,8 +161,6 @@ void setup()
   uint8_t key[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
                     0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
   rf69.setEncryptionKey(key);
-  
-  pinMode(LED, OUTPUT);
 
   Serial.print("RFM69 radio @");  Serial.print((int)RF69_FREQ);  Serial.println(" MHz");
 
@@ -163,12 +177,12 @@ void setup()
 }
 
 
-void loop()
-{  if (rf69.waitAvailableTimeout(100)) {
-    // Should be a message for us now   
+void loop() {
+  if (rf69.waitAvailableTimeout(100)) {
+    // Should be a message for us now
     uint8_t buf[RH_RF69_MAX_MESSAGE_LEN];
     uint8_t len = sizeof(buf);
-    
+
     if (! rf69.recv(buf, &len)) {
       Serial.println("Receive failed");
       return;
@@ -176,7 +190,7 @@ void loop()
     digitalWrite(LED, HIGH);
     rf69.printBuffer("Received: ", buf, len);
     buf[len] = 0;
-    
+
     Serial.print("Got: "); Serial.println((char*)buf);
     Serial.print("RSSI: "); Serial.println(rf69.lastRssi(), DEC);
 
@@ -184,14 +198,14 @@ void loop()
     oled.setCursor(0,0);
     oled.println((char*)buf);
     oled.print("RSSI: "); oled.print(rf69.lastRssi());
-    oled.display(); 
+    oled.display();
     digitalWrite(LED, LOW);
   }
 
   if (!digitalRead(BUTTON_A) || !digitalRead(BUTTON_B) || !digitalRead(BUTTON_C))
   {
     Serial.println("Button pressed!");
-    
+
     char radiopacket[20] = "Button #";
     if (!digitalRead(BUTTON_A)) radiopacket[8] = 'A';
     if (!digitalRead(BUTTON_B)) radiopacket[8] = 'B';
@@ -203,4 +217,3 @@ void loop()
     rf69.waitPacketSent();
   }
 }
-

--- a/examples/feather/RadioHead69_RawDemo_RX/RadioHead69_RawDemo_RX.ino
+++ b/examples/feather/RadioHead69_RawDemo_RX/RadioHead69_RawDemo_RX.ino
@@ -1,12 +1,12 @@
 // rf69 demo tx rx.pde
 // -*- mode: C++ -*-
-// Example sketch showing how to create a simple messageing client
-// with the RH_RF69 class. RH_RF69 class does not provide for addressing or
-// reliability, so you should only use RH_RF69  if you do not need the higher
-// level messaging abilities.
-// It is designed to work with the other example rf69_server.
-// Demonstrates the use of AES encryption, setting the frequency and modem 
-// configuration
+// Example sketch showing how to create a simple messaging client
+// with the RH_RF69 class. RH_RF69 class does not provide for addressing
+// or reliability, so you should only use RH_RF69 if you do not need the
+// higher level messaging abilities.
+// It is designed to work with the other example RadioHead69_RawDemo_TX.
+// Demonstrates the use of AES encryption, setting the frequency and
+// modem configuration
 
 #include <SPI.h>
 #include <RH_RF69.h>
@@ -16,68 +16,69 @@
 // Change to 434.0 or other frequency, must match RX's freq!
 #define RF69_FREQ 915.0
 
-#if defined (__AVR_ATmega32U4__) // Feather 32u4 w/Radio
-  #define RFM69_CS      8
-  #define RFM69_INT     7
-  #define RFM69_RST     4
-  #define LED           13
-#endif
+// First 3 here are boards w/radio BUILT-IN. Boards using FeatherWing follow.
+#if defined (__AVR_ATmega32U4__)  // Feather 32u4 w/Radio
+  #define RFM69_CS    8
+  #define RFM69_INT   7
+  #define RFM69_RST   4
+  #define LED        13
 
-#if defined(ADAFRUIT_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ARDUINO_SAMD_FEATHER_M0)
-  // Feather M0 w/Radio
-  #define RFM69_CS      8
-  #define RFM69_INT     3
-  #define RFM69_RST     4
-  #define LED           13
-#endif
+#elif defined(ADAFRUIT_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ARDUINO_SAMD_FEATHER_M0)  // Feather M0 w/Radio
+  #define RFM69_CS    8
+  #define RFM69_INT   3
+  #define RFM69_RST   4
+  #define LED        13
 
-#if defined (__AVR_ATmega328P__)  // Feather 328P w/wing
-  #define RFM69_INT     3  // 
-  #define RFM69_CS      4  //
-  #define RFM69_RST     2  // "A"
-  #define LED           13
-#endif
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040_RFM)  // Feather RP2040 w/Radio
+  #define RFM69_CS   16
+  #define RFM69_INT  21
+  #define RFM69_RST  17
+  #define LED        LED_BUILTIN
 
-#if defined(ESP8266)    // ESP8266 feather w/wing
-  #define RFM69_CS      2    // "E"
-  #define RFM69_IRQ     15   // "B"
-  #define RFM69_RST     16   // "D"
-  #define LED           0
-#endif
+#elif defined (__AVR_ATmega328P__)  // Feather 328P w/wing
+  #define RFM69_CS    4  //
+  #define RFM69_INT   3  //
+  #define RFM69_RST   2  // "A"
+  #define LED        13
 
-#if defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_NRF52840_FEATHER_SENSE)
-  #define RFM69_INT     9  // "A"
-  #define RFM69_CS      10  // "B"
-  #define RFM69_RST     11  // "C"
-  #define LED           13
+#elif defined(ESP8266)  // ESP8266 feather w/wing
+  #define RFM69_CS    2  // "E"
+  #define RFM69_INT  15  // "B"
+  #define RFM69_RST  16  // "D"
+  #define LED         0
 
-#elif defined(ESP32)    // ESP32 feather w/wing
-  #define RFM69_RST     13   // same as LED
-  #define RFM69_CS      33   // "B"
-  #define RFM69_INT     27   // "A"
-  #define LED           13
-#endif
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_NRF52840_FEATHER_SENSE)
+  #define RFM69_CS   10  // "B"
+  #define RFM69_INT   9  // "A"
+  #define RFM69_RST  11  // "C"
+  #define LED        13
 
-#if defined(ARDUINO_NRF52832_FEATHER)
-  /* nRF52832 feather w/wing */
-  #define RFM69_RST     7   // "A"
-  #define RFM69_CS      11   // "B"
-  #define RFM69_INT     31   // "C"
-  #define LED           17
+#elif defined(ESP32)  // ESP32 feather w/wing
+  #define RFM69_CS   33  // "B"
+  #define RFM69_INT  27  // "A"
+  #define RFM69_RST  13  // same as LED
+  #define LED        13
+
+#elif defined(ARDUINO_NRF52832_FEATHER)  // nRF52832 feather w/wing
+  #define RFM69_CS   11  // "B"
+  #define RFM69_INT  31  // "C"
+  #define RFM69_RST   7  // "A"
+  #define LED        17
+
 #endif
 
 /* Teensy 3.x w/wing
-#define RFM69_RST     9   // "A"
-#define RFM69_CS      10   // "B"
-#define RFM69_IRQ     4    // "C"
-#define RFM69_IRQN    digitalPinToInterrupt(RFM69_IRQ )
+#define RFM69_CS     10  // "B"
+#define RFM69_INT     4  // "C"
+#define RFM69_RST     9  // "A"
+#define RFM69_IRQN   digitalPinToInterrupt(RFM69_INT)
 */
- 
-/* WICED Feather w/wing 
-#define RFM69_RST     PA4     // "A"
-#define RFM69_CS      PB4     // "B"
-#define RFM69_IRQ     PA15    // "C"
-#define RFM69_IRQN    RFM69_IRQ
+
+/* WICED Feather w/wing
+#define RFM69_CS     PB4  // "B"
+#define RFM69_INT    PA15 // "C"
+#define RFM69_RST    PA4  // "A"
+#define RFM69_IRQN   RFM69_INT
 */
 
 // Singleton instance of the radio driver
@@ -85,12 +86,11 @@ RH_RF69 rf69(RFM69_CS, RFM69_INT);
 
 int16_t packetnum = 0;  // packet counter, we increment per xmission
 
-void setup() 
-{
+void setup() {
   Serial.begin(115200);
   //while (!Serial) { delay(1); } // wait until serial console is open, remove if not tethered to computer
 
-  pinMode(LED, OUTPUT);     
+  pinMode(LED, OUTPUT);
   pinMode(RFM69_RST, OUTPUT);
   digitalWrite(RFM69_RST, LOW);
 
@@ -102,13 +102,13 @@ void setup()
   delay(10);
   digitalWrite(RFM69_RST, LOW);
   delay(10);
-  
+
   if (!rf69.init()) {
     Serial.println("RFM69 radio init failed");
     while (1);
   }
   Serial.println("RFM69 radio init OK!");
-  
+
   // Defaults after init are 434.0MHz, modulation GFSK_Rb250Fd250, +13dbM (for low power module)
   // No encryption
   if (!rf69.setFrequency(RF69_FREQ)) {
@@ -123,16 +123,13 @@ void setup()
   uint8_t key[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
                     0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
   rf69.setEncryptionKey(key);
-  
-  pinMode(LED, OUTPUT);
 
   Serial.print("RFM69 radio @");  Serial.print((int)RF69_FREQ);  Serial.println(" MHz");
 }
 
-
 void loop() {
  if (rf69.available()) {
-    // Should be a message for us now   
+    // Should be a message for us now
     uint8_t buf[RH_RF69_MAX_MESSAGE_LEN];
     uint8_t len = sizeof(buf);
     if (rf69.recv(buf, &len)) {
@@ -151,7 +148,7 @@ void loop() {
         rf69.send(data, sizeof(data));
         rf69.waitPacketSent();
         Serial.println("Sent a reply");
-        Blink(LED, 40, 3); //blink LED 3 times, 40ms between blinks
+        Blink(LED, 40, 3); // blink LED 3 times, 40ms between blinks
       }
     } else {
       Serial.println("Receive failed");
@@ -159,12 +156,11 @@ void loop() {
   }
 }
 
-
-void Blink(byte PIN, byte DELAY_MS, byte loops) {
-  for (byte i=0; i<loops; i++)  {
-    digitalWrite(PIN,HIGH);
-    delay(DELAY_MS);
-    digitalWrite(PIN,LOW);
-    delay(DELAY_MS);
+void Blink(byte pin, byte delay_ms, byte loops) {
+  while (loops--) {
+    digitalWrite(pin, HIGH);
+    delay(delay_ms);
+    digitalWrite(pin, LOW);
+    delay(delay_ms);
   }
 }

--- a/examples/feather/RadioHead69_RawDemo_RX/RadioHead69_RawDemo_RX.ino
+++ b/examples/feather/RadioHead69_RawDemo_RX/RadioHead69_RawDemo_RX.ino
@@ -6,7 +6,7 @@
 // higher level messaging abilities.
 // It is designed to work with the other example RadioHead69_RawDemo_TX.
 // Demonstrates the use of AES encryption, setting the frequency and
-// modem configuration
+// modem configuration.
 
 #include <SPI.h>
 #include <RH_RF69.h>
@@ -84,11 +84,9 @@
 // Singleton instance of the radio driver
 RH_RF69 rf69(RFM69_CS, RFM69_INT);
 
-int16_t packetnum = 0;  // packet counter, we increment per xmission
-
 void setup() {
   Serial.begin(115200);
-  //while (!Serial) { delay(1); } // wait until serial console is open, remove if not tethered to computer
+  //while (!Serial) delay(1); // Wait for Serial Console (comment out line if no computer)
 
   pinMode(LED, OUTPUT);
   pinMode(RFM69_RST, OUTPUT);

--- a/examples/feather/RadioHead69_RawDemo_TX/RadioHead69_RawDemo_TX.ino
+++ b/examples/feather/RadioHead69_RawDemo_TX/RadioHead69_RawDemo_TX.ino
@@ -6,7 +6,7 @@
 // higher level messaging abilities.
 // It is designed to work with the other example RadioHead69_RawDemo_RX.
 // Demonstrates the use of AES encryption, setting the frequency and
-// modem configuration
+// modem configuration.
 
 #include <SPI.h>
 #include <RH_RF69.h>
@@ -88,7 +88,7 @@ int16_t packetnum = 0;  // packet counter, we increment per xmission
 
 void setup() {
   Serial.begin(115200);
-  //while (!Serial) { delay(1); } // wait until serial console is open, remove if not tethered to computer
+  //while (!Serial) delay(1); // Wait for Serial Console (comment out line if no computer)
 
   pinMode(LED, OUTPUT);
   pinMode(RFM69_RST, OUTPUT);

--- a/examples/feather/RadioHead69_RawDemo_TX/RadioHead69_RawDemo_TX.ino
+++ b/examples/feather/RadioHead69_RawDemo_TX/RadioHead69_RawDemo_TX.ino
@@ -1,12 +1,12 @@
 // rf69 demo tx rx.pde
 // -*- mode: C++ -*-
-// Example sketch showing how to create a simple messageing client
-// with the RH_RF69 class. RH_RF69 class does not provide for addressing or
-// reliability, so you should only use RH_RF69  if you do not need the higher
-// level messaging abilities.
-// It is designed to work with the other example rf69_server.
-// Demonstrates the use of AES encryption, setting the frequency and modem 
-// configuration
+// Example sketch showing how to create a simple messaging client
+// with the RH_RF69 class. RH_RF69 class does not provide for addressing
+// or reliability, so you should only use RH_RF69 if you do not need the
+// higher level messaging abilities.
+// It is designed to work with the other example RadioHead69_RawDemo_RX.
+// Demonstrates the use of AES encryption, setting the frequency and
+// modem configuration
 
 #include <SPI.h>
 #include <RH_RF69.h>
@@ -16,65 +16,69 @@
 // Change to 434.0 or other frequency, must match RX's freq!
 #define RF69_FREQ 915.0
 
-#if defined (__AVR_ATmega32U4__) // Feather 32u4 w/Radio
-  #define RFM69_CS      8
-  #define RFM69_INT     7
-  #define RFM69_RST     4
-  #define LED           13
-  
-#elif defined(ADAFRUIT_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ARDUINO_SAMD_FEATHER_M0)
-  // Feather M0 w/Radio
-  #define RFM69_CS      8
-  #define RFM69_INT     3
-  #define RFM69_RST     4
-  #define LED           13
-  
-#elif defined (__AVR_ATmega328P__)  // Feather 328P w/wing
-  #define RFM69_INT     3  // 
-  #define RFM69_CS      4  //
-  #define RFM69_RST     2  // "A"
-  #define LED           13
+// First 3 here are boards w/radio BUILT-IN. Boards using FeatherWing follow.
+#if defined (__AVR_ATmega32U4__)  // Feather 32u4 w/Radio
+  #define RFM69_CS    8
+  #define RFM69_INT   7
+  #define RFM69_RST   4
+  #define LED        13
 
-#elif defined(ESP8266)    // ESP8266 feather w/wing
-  #define RFM69_CS      2    // "E"
-  #define RFM69_IRQ     15   // "B"
-  #define RFM69_RST     16   // "D"
-  #define LED           0
+#elif defined(ADAFRUIT_FEATHER_M0) || defined(ADAFRUIT_FEATHER_M0_EXPRESS) || defined(ARDUINO_SAMD_FEATHER_M0)  // Feather M0 w/Radio
+  #define RFM69_CS    8
+  #define RFM69_INT   3
+  #define RFM69_RST   4
+  #define LED        13
+
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040_RFM)  // Feather RP2040 w/Radio
+  #define RFM69_CS   16
+  #define RFM69_INT  21
+  #define RFM69_RST  17
+  #define LED        LED_BUILTIN
+
+#elif defined (__AVR_ATmega328P__)  // Feather 328P w/wing
+  #define RFM69_CS    4  //
+  #define RFM69_INT   3  //
+  #define RFM69_RST   2  // "A"
+  #define LED        13
+
+#elif defined(ESP8266)  // ESP8266 feather w/wing
+  #define RFM69_CS    2  // "E"
+  #define RFM69_INT  15  // "B"
+  #define RFM69_RST  16  // "D"
+  #define LED         0
 
 #elif defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) || defined(ARDUINO_NRF52840_FEATHER) || defined(ARDUINO_NRF52840_FEATHER_SENSE)
-  #define RFM69_INT     9  // "A"
-  #define RFM69_CS      10  // "B"
-  #define RFM69_RST     11  // "C"
-  #define LED           13
+  #define RFM69_CS   10  // "B"
+  #define RFM69_INT   9  // "A"
+  #define RFM69_RST  11  // "C"
+  #define LED        13
 
-#elif defined(ESP32)    // ESP32 feather w/wing
-  #define RFM69_RST     13   // same as LED
-  #define RFM69_CS      33   // "B"
-  #define RFM69_INT     27   // "A"
-  #define LED           13
+#elif defined(ESP32)  // ESP32 feather w/wing
+  #define RFM69_CS   33  // "B"
+  #define RFM69_INT  27  // "A"
+  #define RFM69_RST  13  // same as LED
+  #define LED        13
 
-#elif defined(ARDUINO_NRF52832_FEATHER)
-  /* nRF52832 feather w/wing */
-  #define RFM69_RST     7   // "A"
-  #define RFM69_CS      11   // "B"
-  #define RFM69_INT     31   // "C"
-  #define LED           17
+#elif defined(ARDUINO_NRF52832_FEATHER)  // nRF52832 feather w/wing
+  #define RFM69_CS   11  // "B"
+  #define RFM69_INT  31  // "C"
+  #define RFM69_RST   7  // "A"
+  #define LED        17
 
 #endif
 
-
 /* Teensy 3.x w/wing
-#define RFM69_RST     9   // "A"
-#define RFM69_CS      10   // "B"
-#define RFM69_IRQ     4    // "C"
-#define RFM69_IRQN    digitalPinToInterrupt(RFM69_IRQ )
+#define RFM69_CS     10  // "B"
+#define RFM69_INT     4  // "C"
+#define RFM69_RST     9  // "A"
+#define RFM69_IRQN   digitalPinToInterrupt(RFM69_INT)
 */
- 
-/* WICED Feather w/wing 
-#define RFM69_RST     PA4     // "A"
-#define RFM69_CS      PB4     // "B"
-#define RFM69_IRQ     PA15    // "C"
-#define RFM69_IRQN    RFM69_IRQ
+
+/* WICED Feather w/wing
+#define RFM69_CS     PB4  // "B"
+#define RFM69_INT    PA15 // "C"
+#define RFM69_RST    PA4  // "A"
+#define RFM69_IRQN   RFM69_INT
 */
 
 // Singleton instance of the radio driver
@@ -82,12 +86,11 @@ RH_RF69 rf69(RFM69_CS, RFM69_INT);
 
 int16_t packetnum = 0;  // packet counter, we increment per xmission
 
-void setup() 
-{
+void setup() {
   Serial.begin(115200);
   //while (!Serial) { delay(1); } // wait until serial console is open, remove if not tethered to computer
 
-  pinMode(LED, OUTPUT);     
+  pinMode(LED, OUTPUT);
   pinMode(RFM69_RST, OUTPUT);
   digitalWrite(RFM69_RST, LOW);
 
@@ -99,7 +102,7 @@ void setup()
   delay(10);
   digitalWrite(RFM69_RST, LOW);
   delay(10);
-  
+
   if (!rf69.init()) {
     Serial.println("RFM69 radio init failed");
     while (1);
@@ -119,13 +122,9 @@ void setup()
   uint8_t key[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
                     0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
   rf69.setEncryptionKey(key);
-  
-  pinMode(LED, OUTPUT);
 
   Serial.print("RFM69 radio @");  Serial.print((int)RF69_FREQ);  Serial.println(" MHz");
 }
-
-
 
 void loop() {
   delay(1000);  // Wait 1 second between transmits, could also 'sleep' here!
@@ -133,7 +132,7 @@ void loop() {
   char radiopacket[20] = "Hello World #";
   itoa(packetnum++, radiopacket+13, 10);
   Serial.print("Sending "); Serial.println(radiopacket);
-  
+
   // Send a message!
   rf69.send((uint8_t *)radiopacket, strlen(radiopacket));
   rf69.waitPacketSent();
@@ -142,12 +141,12 @@ void loop() {
   uint8_t buf[RH_RF69_MAX_MESSAGE_LEN];
   uint8_t len = sizeof(buf);
 
-  if (rf69.waitAvailableTimeout(500))  { 
-    // Should be a reply message for us now   
+  if (rf69.waitAvailableTimeout(500)) {
+    // Should be a reply message for us now
     if (rf69.recv(buf, &len)) {
       Serial.print("Got a reply: ");
       Serial.println((char*)buf);
-      Blink(LED, 50, 3); //blink LED 3 times, 50ms between blinks
+      Blink(LED, 50, 3); // blink LED 3 times, 50ms between blinks
     } else {
       Serial.println("Receive failed");
     }
@@ -156,11 +155,11 @@ void loop() {
   }
 }
 
-void Blink(byte PIN, byte DELAY_MS, byte loops) {
-  for (byte i=0; i<loops; i++)  {
-    digitalWrite(PIN,HIGH);
-    delay(DELAY_MS);
-    digitalWrite(PIN,LOW);
-    delay(DELAY_MS);
+void Blink(byte pin, byte delay_ms, byte loops) {
+  while (loops--) {
+    digitalWrite(pin, HIGH);
+    delay(delay_ms);
+    digitalWrite(pin, LOW);
+    delay(delay_ms);
   }
 }


### PR DESCRIPTION
All examples — RFM69 and LoRa — include pin defs for the new RP2040 Feathers. These compile successfully and the RFM69 examples are tested (some Serial strangeness as discussed, but the radio parts work). LoRa are untested (just ordered hardware for this), but as it’s just an equivalent set of pin changes, not expecting any surprises here.

Also some minor reformatting throughout, no functional changes, just y’know how code accumulates unneeded lines and chars and then gets copypasta’d all over the place.